### PR TITLE
Harden Symfony app: fix SSRF, stored XSS, CSRF, and secret exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ football/transactions/livedraft/check.log
 **/.phpunit.result.cache
 
 /plans/
+
+# Security review notes — kept out of the repo; stored separately
+/specs/backlog/securityreview.md

--- a/symfony-app/.env
+++ b/symfony-app/.env
@@ -15,9 +15,17 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
+# Secure default: committed config runs in prod. Override APP_ENV=dev in the
+# uncommitted .env.local for local development. APP_SECRET must be provided per
+# environment (real env var, secrets vault, or .env.local) and is never committed.
+APP_ENV=prod
 APP_SECRET=
 ###< symfony/framework-bundle ###
+
+# Optional extra directory prepended to the legacy PHP include_path (e.g. a
+# shared library dir outside the project). Left empty by default; set it
+# per-environment in .env.local or a real env var. Only used if the dir exists.
+LEGACY_INCLUDE_PATH=
 
 ###> doctrine/doctrine-bundle ###
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url

--- a/symfony-app/.env.dev
+++ b/symfony-app/.env.dev
@@ -1,4 +1,6 @@
 
 ###> symfony/framework-bundle ###
-APP_SECRET=ee617fa33f4835148b7e2792ae0cde82
+# APP_SECRET is intentionally NOT committed. Set it in the uncommitted
+# .env.local (dev) or via a real environment variable / secrets vault.
+# The value previously committed here has been rotated out.
 ###< symfony/framework-bundle ###

--- a/symfony-app/composer.json
+++ b/symfony-app/composer.json
@@ -17,7 +17,9 @@
         "symfony/dotenv": "7.4.*",
         "symfony/flex": "^2",
         "symfony/framework-bundle": "7.4.*",
+        "symfony/html-sanitizer": "7.4.*",
         "symfony/runtime": "7.4.*",
+        "symfony/security-csrf": "7.4.*",
         "symfony/twig-bundle": "7.4.*",
         "symfony/yaml": "7.4.*"
     },

--- a/symfony-app/composer.lock
+++ b/symfony-app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50ef877dbff768330dfe5364044ba161",
+    "content-hash": "d6a1f9fdd13b4bab917f91afd567af59",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -1128,6 +1128,255 @@
             "time": "2025-10-26T09:35:14+00:00"
         },
         {
+            "name": "league/uri",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "URN",
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc2141",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "rfc8141",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "3.0.0",
             "source": {
@@ -1278,6 +1527,114 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2667,6 +3024,80 @@
             "time": "2025-12-29T09:31:36+00:00"
         },
         {
+            "name": "symfony/html-sanitizer",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/html-sanitizer.git",
+                "reference": "c328df69f5b6f44a0d031d757903d955bebb23b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/c328df69f5b6f44a0d031d757903d955bebb23b3",
+                "reference": "c328df69f5b6f44a0d031d757903d955bebb23b3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "league/uri": "^6.5|^7.0",
+                "masterminds/html5": "^2.7.2",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HtmlSanitizer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to sanitize untrusted HTML input for safe insertion into a document's DOM.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "Purifier",
+                "html",
+                "sanitizer"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/html-sanitizer/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-06T11:10:32+00:00"
+        },
+        {
             "name": "symfony/http-foundation",
             "version": "v7.4.3",
             "source": {
@@ -2866,6 +3297,82 @@
                 }
             ],
             "time": "2025-12-31T08:43:57+00:00"
+        },
+        {
+            "name": "symfony/password-hasher",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/password-hasher.git",
+                "reference": "18a7d92126c95962f7efbcc9e421ba710a366847"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/18a7d92126c95962f7efbcc9e421ba710a366847",
+                "reference": "18a7d92126c95962f7efbcc9e421ba710a366847",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/security-core": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/security-core": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PasswordHasher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin Chalas",
+                    "email": "robin.chalas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides password hashing utilities",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/password-hasher/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -3446,6 +3953,171 @@
                 }
             ],
             "time": "2025-12-05T14:04:53+00:00"
+        },
+        {
+            "name": "symfony/security-core",
+            "version": "v7.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-core.git",
+                "reference": "880bb18eff6188d55115e795f06e4185373c35fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/880bb18eff6188d55115e795f06e4185373c35fd",
+                "reference": "880bb18eff6188d55115e795f06e4185373c35fd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/event-dispatcher-contracts": "^2.5|^3",
+                "symfony/password-hasher": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/http-foundation": "<6.4",
+                "symfony/ldap": "<6.4",
+                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
+                "symfony/validator": "<6.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "psr/container": "^1.1|^2.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/ldap": "^6.4|^7.0|^8.0",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4.3|^7.0.3|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Core\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - Core Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-core/tree/v7.4.14"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-09T07:51:57+00:00"
+        },
+        {
+            "name": "symfony/security-csrf",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-csrf.git",
+                "reference": "16b3aa2f67d02fb0dbd013a8759bbe90daaa9c5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/16b3aa2f67d02fb0dbd013a8759bbe90daaa9c5d",
+                "reference": "16b3aa2f67d02fb0dbd013a8759bbe90daaa9c5d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/security-core": "^6.4|^7.0|^8.0"
+            },
+            "conflict": {
+                "symfony/http-foundation": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Csrf\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - CSRF Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-csrf/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4303,73 +4975,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "masterminds/html5",
-            "version": "2.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
-                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Masterminds\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Matt Butcher",
-                    "email": "technosophos@gmail.com"
-                },
-                {
-                    "name": "Matt Farina",
-                    "email": "matt@mattfarina.com"
-                },
-                {
-                    "name": "Asmir Mustafic",
-                    "email": "goetas@gmail.com"
-                }
-            ],
-            "description": "An HTML5 parser and serializer.",
-            "homepage": "http://masterminds.github.io/html5-php",
-            "keywords": [
-                "HTML5",
-                "dom",
-                "html",
-                "parser",
-                "querypath",
-                "serializer",
-                "xml"
-            ],
-            "support": {
-                "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
-            },
-            "time": "2025-07-25T09:04:22+00:00"
-        },
         {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",

--- a/symfony-app/config/packages/framework.yaml
+++ b/symfony-app/config/packages/framework.yaml
@@ -5,6 +5,9 @@ framework:
     # Note that the session will be started ONLY if you read or write from it.
     session: true
 
+    # CSRF tokens for hand-built HTML forms (validated via isCsrfTokenValid()).
+    csrf_protection: true
+
     #esi: true
     #fragments: true
 

--- a/symfony-app/config/packages/html_sanitizer.yaml
+++ b/symfony-app/config/packages/html_sanitizer.yaml
@@ -1,0 +1,14 @@
+framework:
+    html_sanitizer:
+        sanitizers:
+            # Sanitizer for member/admin-authored article HTML. Allows the
+            # standard safe formatting elements (paragraphs, links, images,
+            # headings, lists, emphasis, tables) while stripping <script>,
+            # inline event handlers and javascript:/data: URLs. Relative URLs
+            # are kept because article images are served from relative paths
+            # like img/l/{hash}.
+            app.article:
+                allow_safe_elements: true
+                allow_static_elements: true
+                allow_relative_links: true
+                allow_relative_medias: true

--- a/symfony-app/config/reference.php
+++ b/symfony-app/config/reference.php
@@ -653,7 +653,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         time_based_uuid_node?: scalar|null|Param,
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *         sanitizers?: array<string, array{ // Default: []
  *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
  *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false

--- a/symfony-app/public/base/js/admin/money.js
+++ b/symfony-app/public/base/js/admin/money.js
@@ -33,7 +33,8 @@ function toggleChange(event) {
     console.log("Send "+inputElement.id+ " a new value of "+newValue);
     $.post("recordChange", {
         field: inputElement.id,
-        val: newValue
+        val: newValue,
+        _token: window.moneyCsrfToken
     }, function(response) {
         console.log(response);
     }, "json");
@@ -46,7 +47,8 @@ function sendChange(event) {
     console.log("Send "+inputElement.id+ " a new value of "+newValue);
     $.post("recordChange", {
         field: inputElement.id,
-        val: newValue
+        val: newValue,
+        _token: window.moneyCsrfToken
     }, function(response) {
         console.log(response);
     }, "json");

--- a/symfony-app/src/Controller/Admin/AbstractAdminController.php
+++ b/symfony-app/src/Controller/Admin/AbstractAdminController.php
@@ -5,6 +5,8 @@ namespace App\Controller\Admin;
 use App\Service\AuthenticationService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 abstract class AbstractAdminController extends AbstractController
 {
@@ -14,5 +16,17 @@ abstract class AbstractAdminController extends AbstractController
             return new RedirectResponse('/');
         }
         return null;
+    }
+
+    /**
+     * Reject a POST whose CSRF token (submitted as the `_token` field) does not
+     * match the given id, throwing a 403. Call at the top of every mutating
+     * admin action, after the commissioner check.
+     */
+    protected function assertCsrfToken(Request $request, string $id): void
+    {
+        if (!$this->isCsrfTokenValid($id, (string) $request->getPayload()->get('_token'))) {
+            throw new AccessDeniedHttpException('Invalid CSRF token');
+        }
     }
 }

--- a/symfony-app/src/Controller/Admin/AdminArticleController.php
+++ b/symfony-app/src/Controller/Admin/AdminArticleController.php
@@ -8,6 +8,7 @@ use App\Repository\ArticleRepository;
 use App\Service\ArticleImageService;
 use App\Service\AuthenticationService;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -32,7 +33,8 @@ class AdminArticleController extends AbstractAdminController
         Request $request,
         AuthenticationService $auth,
         EntityManagerInterface $em,
-        ArticleImageService $images
+        ArticleImageService $images,
+        HtmlSanitizerInterface $appArticle
     ): Response {
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
@@ -42,7 +44,10 @@ class AdminArticleController extends AbstractAdminController
         $article->setDisplayDate(new \DateTime());
         $article->setActive(true);
 
-        if ($request->isMethod('POST') && $this->applyForm($request, $article, $em, $images)) {
+        if ($request->isMethod('POST')) {
+            $this->assertCsrfToken($request, 'admin_article');
+        }
+        if ($request->isMethod('POST') && $this->applyForm($request, $article, $em, $images, $appArticle)) {
             $em->persist($article);
             $em->flush();
             $this->addFlash('success', 'Article created');
@@ -60,7 +65,8 @@ class AdminArticleController extends AbstractAdminController
         AuthenticationService $auth,
         ArticleRepository $articles,
         EntityManagerInterface $em,
-        ArticleImageService $images
+        ArticleImageService $images,
+        HtmlSanitizerInterface $appArticle
     ): Response {
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
@@ -71,8 +77,11 @@ class AdminArticleController extends AbstractAdminController
             throw $this->createNotFoundException("No article with id $id");
         }
 
+        if ($request->isMethod('POST')) {
+            $this->assertCsrfToken($request, 'admin_article');
+        }
         $wasActive = (bool) $article->isActive();
-        if ($request->isMethod('POST') && $this->applyForm($request, $article, $em, $images)) {
+        if ($request->isMethod('POST') && $this->applyForm($request, $article, $em, $images, $appArticle)) {
             if ($wasActive) {
                 // Editing live content; drafts never get a lastEdited date
                 $article->setLastEdited(new \DateTime());
@@ -89,6 +98,7 @@ class AdminArticleController extends AbstractAdminController
     #[Route('/{id}/toggle', name: 'admin_articles_toggle', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function toggle(
         int $id,
+        Request $request,
         AuthenticationService $auth,
         ArticleRepository $articles,
         EntityManagerInterface $em
@@ -96,6 +106,7 @@ class AdminArticleController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_article_toggle');
 
         $article = $articles->find($id);
         if (!$article) {
@@ -116,7 +127,8 @@ class AdminArticleController extends AbstractAdminController
         Request $request,
         Article $article,
         EntityManagerInterface $em,
-        ArticleImageService $images
+        ArticleImageService $images,
+        HtmlSanitizerInterface $appArticle
     ): bool {
         $title = trim($request->request->get('title', ''));
         if ($title === '') {
@@ -161,7 +173,10 @@ class AdminArticleController extends AbstractAdminController
         $article->setTitle($title);
         $article->setCaption(trim($request->request->get('caption', '')) ?: null);
         $article->setLink($link ?: null);
-        $article->setText($request->request->get('text', '') ?: null);
+        // Sanitize at save time so stored HTML is already safe (keeps the full
+        // TinyMCE formatting set; see the app.article sanitizer config).
+        $text = $appArticle->sanitize($request->request->get('text', ''));
+        $article->setText($text ?: null);
         $article->setDisplayDate($displayDate);
         $article->setPriority($request->request->getInt('priority'));
         $article->setActive($request->request->has('active'));

--- a/symfony-app/src/Controller/Admin/AdminBallotController.php
+++ b/symfony-app/src/Controller/Admin/AdminBallotController.php
@@ -113,6 +113,7 @@ class AdminBallotController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_ballot');
 
         $issue = new Issue();
         $this->hydrateIssue($issue, $request, $em);
@@ -157,6 +158,8 @@ class AdminBallotController extends AbstractAdminController
             return $redirect;
         }
 
+        $this->assertCsrfToken($request, 'admin_ballot');
+
         $issue = $em->getRepository(Issue::class)->find($id);
         if (!$issue) {
             throw $this->createNotFoundException();
@@ -178,6 +181,7 @@ class AdminBallotController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_ballot_publish');
 
         $issue = $em->getRepository(Issue::class)->find($id);
         if (!$issue) {

--- a/symfony-app/src/Controller/Admin/AdminBecomeController.php
+++ b/symfony-app/src/Controller/Admin/AdminBecomeController.php
@@ -20,6 +20,7 @@ class AdminBecomeController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_become');
 
         $teamId = (int) $request->request->get('teamId');
 

--- a/symfony-app/src/Controller/Admin/AdminCommentController.php
+++ b/symfony-app/src/Controller/Admin/AdminCommentController.php
@@ -52,6 +52,7 @@ class AdminCommentController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_comment_toggle');
 
         $comment = $comments->find($id);
         if (!$comment) {

--- a/symfony-app/src/Controller/Admin/AdminHeadCoachController.php
+++ b/symfony-app/src/Controller/Admin/AdminHeadCoachController.php
@@ -50,6 +50,7 @@ class AdminHeadCoachController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_headcoach');
 
         $teamId   = (int) $request->request->get('team');
         $playerId = (int) $request->request->get('player');
@@ -110,6 +111,7 @@ class AdminHeadCoachController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_headcoach');
 
         $playerId = (int) $request->request->get('player');
         $now      = (new \DateTime())->format('Y-m-d H:i:s');

--- a/symfony-app/src/Controller/Admin/AdminMoneyController.php
+++ b/symfony-app/src/Controller/Admin/AdminMoneyController.php
@@ -46,17 +46,25 @@ class AdminMoneyController extends AbstractAdminController
         if (!$auth->isCommissioner()) {
             return new JsonResponse(['error' => 'Unauthorized'], Response::HTTP_FORBIDDEN);
         }
+        if (!$this->isCsrfTokenValid('admin_money_record', (string) $request->getPayload()->get('_token'))) {
+            return new JsonResponse(['error' => 'Invalid CSRF token'], Response::HTTP_FORBIDDEN);
+        }
 
-        $field = $request->request->get('field');
+        $field = (string) $request->request->get('field');
         $val   = $request->request->get('val');
 
         $parts = explode('-', $field, 2);
+        if (count($parts) !== 2 || !in_array($parts[0], ['paid', 'late', 'amt'], true) || !ctype_digit($parts[1])) {
+            return new JsonResponse(['error' => 'Invalid field'], Response::HTTP_BAD_REQUEST);
+        }
         $param = $parts[0];
         $idx   = (int) $parts[1];
 
         try {
-            /** @var Paid $paid */
             $paid = $em->find(Paid::class, $idx);
+            if (!$paid instanceof Paid) {
+                return new JsonResponse(['error' => 'Record not found'], Response::HTTP_NOT_FOUND);
+            }
 
             switch ($param) {
                 case 'paid':
@@ -109,6 +117,7 @@ class AdminMoneyController extends AbstractAdminController
         if (!$auth->isCommissioner()) {
             return new RedirectResponse('/');
         }
+        $this->assertCsrfToken($request, 'admin_money_flags');
 
         $season = (int) $request->request->get('season');
         $flags = [];

--- a/symfony-app/src/Controller/Admin/AdminScoresController.php
+++ b/symfony-app/src/Controller/Admin/AdminScoresController.php
@@ -40,6 +40,7 @@ class AdminScoresController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_scores');
 
         $season = (int) $request->request->get('season');
         $week   = (int) $request->request->get('week');

--- a/symfony-app/src/Controller/Admin/AdminTeamController.php
+++ b/symfony-app/src/Controller/Admin/AdminTeamController.php
@@ -57,6 +57,7 @@ class AdminTeamController extends AbstractAdminController
         if ($redirect = $this->requireCommissioner($auth)) {
             return $redirect;
         }
+        $this->assertCsrfToken($request, 'admin_team');
 
         $season = $seasonWeek->getCurrentSeason();
         $teamNames = $em->getRepository(TeamNames::class)->findBy(['season' => $season]);

--- a/symfony-app/src/Controller/ArticleController.php
+++ b/symfony-app/src/Controller/ArticleController.php
@@ -85,6 +85,12 @@ class ArticleController extends AbstractController
             return $this->redirectToRoute('article_view', ['id' => $id]);
         }
 
+        if (!$this->isCsrfTokenValid('comment', (string) $request->getPayload()->get('_token'))) {
+            $this->addFlash('error', 'Your session expired; please try again');
+
+            return $this->redirectToRoute('article_view', ['id' => $id]);
+        }
+
         $text = trim($request->request->get('text', ''));
         if ($text === '') {
             $this->addFlash('error', 'A comment cannot be empty');

--- a/symfony-app/src/Controller/ArticlePublishController.php
+++ b/symfony-app/src/Controller/ArticlePublishController.php
@@ -9,6 +9,7 @@ use App\Service\ArticleImageService;
 use App\Service\AuthenticationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -60,10 +61,15 @@ class ArticlePublishController extends AbstractController
         AuthenticationService $auth,
         ArticleRepository $articles,
         EntityManagerInterface $em,
-        ArticleImageService $images
+        ArticleImageService $images,
+        HtmlSanitizerInterface $appArticle
     ): Response {
         if (!$auth->isLoggedIn()) {
             return $this->render('article/publish.html.twig', ['isLoggedIn' => false]);
+        }
+
+        if (!$this->isCsrfTokenValid('article_publish', (string) $request->getPayload()->get('_token'))) {
+            throw new AccessDeniedHttpException('Invalid CSRF token');
         }
 
         $draft = null;
@@ -135,7 +141,10 @@ class ArticlePublishController extends AbstractController
 
         $draft->setTitle($title);
         $draft->setCaption($caption ?: null);
-        $draft->setText($text);
+        // Strip everything the article sanitizer disallows at save time, so the
+        // stored HTML is already safe rather than relying only on render-time
+        // sanitizing. Keeps the full TinyMCE formatting set (see app.article).
+        $draft->setText($appArticle->sanitize($text));
         if ($link !== null) {
             $draft->setLink($link);
         }
@@ -166,6 +175,10 @@ class ArticlePublishController extends AbstractController
         ArticleRepository $articles,
         EntityManagerInterface $em
     ): Response {
+        if (!$this->isCsrfTokenValid('article_confirm', (string) $request->getPayload()->get('_token'))) {
+            throw new AccessDeniedHttpException('Invalid CSRF token');
+        }
+
         $article = $this->findOwnedArticle($id, $auth, $articles);
 
         if ($request->request->has('Edit')) {

--- a/symfony-app/src/EventSubscriber/AdminAccessSubscriber.php
+++ b/symfony-app/src/EventSubscriber/AdminAccessSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Service\AuthenticationService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Central guard for the /admin area: every controller under
+ * App\Controller\Admin requires a commissioner. Enforcing it here in one place
+ * means a newly added admin controller can't silently ship without the check.
+ *
+ * The per-action requireCommissioner() calls stay in place as the layer that
+ * defines each endpoint's exact response (and are what the controller unit
+ * tests exercise, since those call the actions directly); this subscriber is
+ * the safety net for real HTTP requests. It mirrors requireCommissioner() by
+ * redirecting non-commissioners to '/'.
+ */
+class AdminAccessSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private AuthenticationService $auth)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::CONTROLLER => 'onController'];
+    }
+
+    public function onController(ControllerEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $controller = $event->getController();
+        $class = match (true) {
+            is_array($controller) => $controller[0]::class,
+            is_object($controller) => $controller::class,
+            default => '',
+        };
+
+        if (!str_starts_with($class, 'App\\Controller\\Admin\\')) {
+            return;
+        }
+
+        if (!$this->auth->isCommissioner()) {
+            $event->setController(static fn (): RedirectResponse => new RedirectResponse('/'));
+        }
+    }
+}

--- a/symfony-app/src/LegacyBridge.php
+++ b/symfony-app/src/LegacyBridge.php
@@ -30,10 +30,16 @@ class LegacyBridge
         $projectRoot = dirname(__DIR__, 2);
         $legacyRoot = $projectRoot . '/football';
 
-        // Set up the include path
-        $includePath = '/home/joshutt/php';
-        $includePath .= PATH_SEPARATOR.$legacyRoot;
+        // Set up the include path. An optional extra directory (e.g. a shared
+        // PHP library dir outside the project) can be supplied per-environment
+        // via the LEGACY_INCLUDE_PATH env var instead of being hard-coded.
+        $includePath = $legacyRoot;
         $includePath .= PATH_SEPARATOR.$projectRoot;
+
+        $extraIncludePath = $_SERVER['LEGACY_INCLUDE_PATH'] ?? $_ENV['LEGACY_INCLUDE_PATH'] ?? '';
+        if ($extraIncludePath !== '' && is_dir($extraIncludePath)) {
+            $includePath = $extraIncludePath.PATH_SEPARATOR.$includePath;
+        }
 
         // Add src, lib and conf if the directories exist
         if (is_dir($projectRoot.'/src')) {

--- a/symfony-app/src/Service/ArticleImageService.php
+++ b/symfony-app/src/Service/ArticleImageService.php
@@ -20,13 +20,37 @@ class ArticleImageService
     ) {
     }
 
+    private const MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024;
+    private const FETCH_TIMEOUT_SECONDS = 10;
+
     /**
      * Resize, re-encode and store an image from a local file or URL,
      * returning the link path (img/l/{hash}) to put on the article.
      *
+     * A remote URL is downloaded through a hardened fetch (SSRF-guarded:
+     * http/https only, resolved to a public IP, no redirects, size-capped)
+     * to a local temp file; only that local file is ever handed to GD.
+     *
      * @throws \RuntimeException when the source is not a usable image
      */
     public function store(string $source): string
+    {
+        $tempFile = null;
+        if (preg_match('#^https?://#i', $source)) {
+            $tempFile = $this->fetchRemoteImage($source);
+            $source = $tempFile;
+        }
+
+        try {
+            return $this->storeLocalFile($source);
+        } finally {
+            if ($tempFile !== null && is_file($tempFile)) {
+                @unlink($tempFile);
+            }
+        }
+    }
+
+    private function storeLocalFile(string $source): string
     {
         $info = @getimagesize($source);
         if ($info === false) {
@@ -84,5 +108,104 @@ class ArticleImageService
         imagecopyresampled($resized, $image, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
 
         return $resized;
+    }
+
+    /**
+     * Download a remote image URL to a local temp file with SSRF protections:
+     * only http/https, the host must resolve to a public IP, the connection is
+     * pinned to that validated IP (blocking DNS-rebinding), redirects are
+     * refused, and the body is size-capped. The caller deletes the temp file.
+     *
+     * @throws \RuntimeException on any disallowed or failed fetch
+     */
+    private function fetchRemoteImage(string $url): string
+    {
+        $parts = parse_url($url);
+        if ($parts === false || empty($parts['host']) || empty($parts['scheme'])) {
+            throw new \RuntimeException('Provide a valid image URL');
+        }
+
+        $scheme = strtolower($parts['scheme']);
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            throw new \RuntimeException('Image URL must use http or https');
+        }
+
+        $host = $parts['host'];
+        $port = $parts['port'] ?? ($scheme === 'https' ? 443 : 80);
+        $ip = $this->resolvePublicIp($host);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'articleimg_');
+        if ($tempFile === false) {
+            throw new \RuntimeException('Could not process the image');
+        }
+
+        $handle = fopen($tempFile, 'wb');
+        if ($handle === false) {
+            @unlink($tempFile);
+            throw new \RuntimeException('Could not process the image');
+        }
+
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL => $url,
+            // Pin the hostname to the IP we validated so a second DNS lookup
+            // inside curl can't swing to an internal address (DNS rebinding).
+            CURLOPT_RESOLVE => ["$host:$port:$ip"],
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_CONNECTTIMEOUT => self::FETCH_TIMEOUT_SECONDS,
+            CURLOPT_TIMEOUT => self::FETCH_TIMEOUT_SECONDS,
+            CURLOPT_FILE => $handle,
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_MAXFILESIZE => self::MAX_DOWNLOAD_BYTES,
+            // Enforce the size cap even when no Content-Length is sent.
+            CURLOPT_NOPROGRESS => false,
+            CURLOPT_PROGRESSFUNCTION => static function ($ch, $dlTotal, $dlNow) {
+                return $dlNow > self::MAX_DOWNLOAD_BYTES ? 1 : 0;
+            },
+        ]);
+
+        $ok = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+        fclose($handle);
+
+        if ($ok === false || $status < 200 || $status >= 300) {
+            @unlink($tempFile);
+            throw new \RuntimeException('Could not download the image URL');
+        }
+
+        return $tempFile;
+    }
+
+    /**
+     * Resolve a hostname to a single IP address that is guaranteed to be
+     * public, rejecting private, loopback, link-local and reserved ranges
+     * (IPv4 and IPv6). Every resolved address must be public — if a host
+     * has any internal address we refuse it rather than pick a public one.
+     *
+     * @throws \RuntimeException when the host is unresolvable or non-public
+     */
+    private function resolvePublicIp(string $host): string
+    {
+        // A literal IP in the URL still has to pass the public-range check.
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            $ips = [$host];
+        } else {
+            $v4 = gethostbynamel($host) ?: [];
+            $v6 = array_column(@dns_get_record($host, DNS_AAAA) ?: [], 'ipv6');
+            $ips = array_merge($v4, $v6);
+        }
+
+        if (!$ips) {
+            throw new \RuntimeException('Could not resolve the image URL host');
+        }
+
+        foreach ($ips as $ip) {
+            if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                throw new \RuntimeException('Image URL host is not allowed');
+            }
+        }
+
+        return $ips[0];
     }
 }

--- a/symfony-app/templates/admin/article/form.html.twig
+++ b/symfony-app/templates/admin/article/form.html.twig
@@ -11,6 +11,7 @@
 <h2 class="mt-2">{{ isNew ? 'New Article' : 'Edit Article' }}</h2>
 
 <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="_token" value="{{ csrf_token('admin_article') }}"/>
     <div class="form-group">
         <label for="title">Title</label>
         <input type="text" class="form-control" id="title" name="title" maxlength="75"

--- a/symfony-app/templates/admin/article/index.html.twig
+++ b/symfony-app/templates/admin/article/index.html.twig
@@ -31,6 +31,7 @@
             <td class="text-center">
                 <a class="btn btn-sm btn-wmffl" href="{{ path('admin_articles_edit', {id: article.id}) }}">Edit</a>
                 <form class="d-inline" method="post" action="{{ path('admin_articles_toggle', {id: article.id}) }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('admin_article_toggle') }}"/>
                     <button type="submit" class="btn btn-sm btn-wmffl">{{ article.active ? 'Deactivate' : 'Activate' }}</button>
                 </form>
             </td>

--- a/symfony-app/templates/admin/ballot/form.html.twig
+++ b/symfony-app/templates/admin/ballot/form.html.twig
@@ -6,6 +6,7 @@
 <h2 class="mt-2">{{ issue ? 'Edit Issue' : 'New Issue' }}</h2>
 
 <form method="post" action="{{ issue ? path('admin_ballot_update', {id: issue.id}) : path('admin_ballot_create') }}" style="max-width: 600px;">
+    <input type="hidden" name="_token" value="{{ csrf_token('admin_ballot') }}"/>
 
     <div class="mb-3">
         <label class="form-label">Issue Number <span class="text-danger">*</span></label>

--- a/symfony-app/templates/admin/ballot/index.html.twig
+++ b/symfony-app/templates/admin/ballot/index.html.twig
@@ -108,6 +108,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <form method="post" id="publishForm">
+                <input type="hidden" name="_token" value="{{ csrf_token('admin_ballot_publish') }}"/>
                 <div class="modal-header">
                     <h5 class="modal-title">Put on Ballot — <span id="publishIssueName"></span></h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>

--- a/symfony-app/templates/admin/comment/index.html.twig
+++ b/symfony-app/templates/admin/comment/index.html.twig
@@ -27,6 +27,7 @@
             <td class="text-center">
                 <form class="d-inline" method="post" action="{{ path('admin_comments_toggle', {id: comment.id}) }}">
                     <input type="hidden" name="page" value="{{ page }}"/>
+                    <input type="hidden" name="_token" value="{{ csrf_token('admin_comment_toggle') }}"/>
                     <button type="submit" class="btn btn-sm btn-wmffl">{{ comment.active == true ? 'Deactivate' : 'Activate' }}</button>
                 </form>
             </td>

--- a/symfony-app/templates/admin/dashboard/index.html.twig
+++ b/symfony-app/templates/admin/dashboard/index.html.twig
@@ -55,6 +55,7 @@
             <td>
                 {% if user.team %}
                 <form action="{{ path('admin_become_as') }}" method="POST">
+                    <input type="hidden" name="_token" value="{{ csrf_token('admin_become') }}">
                     <input type="hidden" name="teamId" value="{{ user.team.id }}">
                     <button type="submit" class="btn btn-sm btn-wmffl">Become</button>
                 </form>

--- a/symfony-app/templates/admin/headcoach/index.html.twig
+++ b/symfony-app/templates/admin/headcoach/index.html.twig
@@ -6,6 +6,7 @@
 <h2 class="mt-2">Head Coach Change</h2>
 
 <form action="{{ path('admin_headcoach_process') }}" method="POST">
+    <input type="hidden" name="_token" value="{{ csrf_token('admin_headcoach') }}"/>
     <div class="form-group mb-3">
         <label for="team"><strong>Team</strong></label>
         <select name="team" id="team" class="form-control">
@@ -35,6 +36,7 @@
                 <td>
                     {% if coach.wmfflTeam %}
                     <form action="{{ path('admin_headcoach_drop') }}" method="POST">
+                        <input type="hidden" name="_token" value="{{ csrf_token('admin_headcoach') }}">
                         <input type="hidden" name="player" value="{{ coach.playerid }}">
                         <button type="submit" class="btn btn-sm btn-danger">Drop</button>
                     </form>

--- a/symfony-app/templates/admin/money/updateFlags.html.twig
+++ b/symfony-app/templates/admin/money/updateFlags.html.twig
@@ -7,6 +7,7 @@
     <div class="card-header font-weight-bold text-center">{{ season }} Season Flags</div>
     <div class="card-body p-0">
         <form action="{{ path('admin_money_process_flags') }}" method="post">
+            <input type="hidden" name="_token" value="{{ csrf_token('admin_money_flags') }}"/>
             <input type="hidden" name="season" value="{{ season }}"/>
             <table class="table table-striped table-hover table-sm text-center mb-0">
                 <thead>

--- a/symfony-app/templates/admin/money/updatePaid.html.twig
+++ b/symfony-app/templates/admin/money/updatePaid.html.twig
@@ -3,6 +3,7 @@
 {% block title %}{{ season }} Paid Status - Admin{% endblock %}
 
 {% block javascripts %}
+<script>window.moneyCsrfToken = "{{ csrf_token('admin_money_record') }}";</script>
 <script src="/base/js/admin/money.js"></script>
 {% endblock %}
 

--- a/symfony-app/templates/admin/scores/index.html.twig
+++ b/symfony-app/templates/admin/scores/index.html.twig
@@ -46,6 +46,7 @@
             <div class="card-body text-center">
                 <p class="card-text">{{ currentSeason }} &mdash; Week {{ currentWeek }}</p>
                 <form method="post" action="{{ path('admin_scores_reprocess') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('admin_scores') }}">
                     <input type="hidden" name="season" value="{{ currentSeason }}">
                     <input type="hidden" name="week" value="{{ currentWeek }}">
                     <div class="text-center">
@@ -62,6 +63,7 @@
             <div class="card-body text-center">
                 <p class="card-text">{{ previousSeason }} &mdash; Week {{ previousWeek }}</p>
                 <form method="post" action="{{ path('admin_scores_reprocess') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('admin_scores') }}">
                     <input type="hidden" name="season" value="{{ previousSeason }}">
                     <input type="hidden" name="week" value="{{ previousWeek }}">
                     <div class="text-center">
@@ -77,6 +79,7 @@
             <div class="card-header">Specific Week</div>
             <div class="card-body">
                 <form method="post" action="{{ path('admin_scores_reprocess') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('admin_scores') }}">
                     <div class="mb-2">
                         <label class="form-label">Season</label>
                         <input type="number" name="season" class="form-control" value="{{ currentSeason }}" min="2000" max="2099" required>

--- a/symfony-app/templates/admin/team/updateTeamInfo.html.twig
+++ b/symfony-app/templates/admin/team/updateTeamInfo.html.twig
@@ -6,6 +6,7 @@
 <h2 class="mt-2">Teams {{ season }}</h2>
 
 <form action="{{ path('admin_team_process') }}" method="POST">
+    <input type="hidden" name="_token" value="{{ csrf_token('admin_team') }}"/>
     <table class="table table-sm table-bordered">
         <thead class="thead-dark">
             <tr>

--- a/symfony-app/templates/article/_article.html.twig
+++ b/symfony-app/templates/article/_article.html.twig
@@ -19,5 +19,5 @@
     {% endif %}
 </div>
 <div class="mainStory">
-    <div class="mt-2">{{ article.text|raw }}</div>
+    <div class="mt-2">{{ article.text|sanitize_html('app.article') }}</div>
 </div>

--- a/symfony-app/templates/article/_comment.html.twig
+++ b/symfony-app/templates/article/_comment.html.twig
@@ -9,6 +9,7 @@
         <form class="d-none mt-2" id="reply-form-{{ node.comment.id }}" method="post"
               action="{{ path('article_comment', {id: article.id}) }}">
             <input type="hidden" name="parent" value="{{ node.comment.id }}"/>
+            <input type="hidden" name="_token" value="{{ csrf_token('comment') }}"/>
             <div class="form-group">
                 <textarea class="form-control" name="text" rows="2"></textarea>
             </div>

--- a/symfony-app/templates/article/_comments.html.twig
+++ b/symfony-app/templates/article/_comments.html.twig
@@ -12,6 +12,7 @@
 
     {% if isLoggedIn %}
         <form class="mt-3" method="post" action="{{ path('article_comment', {id: article.id}) }}">
+            <input type="hidden" name="_token" value="{{ csrf_token('comment') }}"/>
             <div class="form-group">
                 <label class="font-weight-bold" for="comment-text">Add a comment:</label>
                 <textarea class="form-control" id="comment-text" name="text" rows="3"></textarea>

--- a/symfony-app/templates/article/preview.html.twig
+++ b/symfony-app/templates/article/preview.html.twig
@@ -7,6 +7,7 @@
     {{ include('article/_article.html.twig') }}
 
     <form action="{{ path('article_confirm', {id: article.id}) }}" method="post">
+        <input type="hidden" name="_token" value="{{ csrf_token('article_confirm') }}"/>
         <div class="text-center my-3">
             <input type="submit" class="btn btn-wmffl" name="Edit" value="Edit"/>
             <input type="submit" class="btn btn-wmffl" name="Publish" value="Publish"/>

--- a/symfony-app/templates/article/publish.html.twig
+++ b/symfony-app/templates/article/publish.html.twig
@@ -20,6 +20,7 @@
         {% endfor %}
 
         <form method="POST" action="{{ path('article_publish') }}" enctype="multipart/form-data">
+            <input type="hidden" name="_token" value="{{ csrf_token('article_publish') }}"/>
             {% if draft %}
                 <input type="hidden" name="draft" value="{{ draft.id }}"/>
             {% endif %}

--- a/symfony-app/tests/Controller/AdminArticleControllerTest.php
+++ b/symfony-app/tests/Controller/AdminArticleControllerTest.php
@@ -12,6 +12,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -72,7 +74,7 @@ class AdminArticleControllerTest extends TestCase
     {
         [$controller, $auth, $em, $images] = $this->makeController(commissioner: false);
 
-        $response = $controller->new(new Request(), $auth, $em, $images);
+        $response = $controller->new(new Request(), $auth, $em, $images, $this->makeSanitizer());
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('/', $response->getTargetUrl());
@@ -82,7 +84,7 @@ class AdminArticleControllerTest extends TestCase
     {
         [$controller, $auth, $em, $images] = $this->makeController(commissioner: true);
 
-        $controller->new(new Request(), $auth, $em, $images);
+        $controller->new(new Request(), $auth, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('admin/article/form.html.twig', $controller->renderedView);
         $this->assertTrue($controller->renderedParams['isNew']);
@@ -95,7 +97,7 @@ class AdminArticleControllerTest extends TestCase
         $em->expects($this->once())->method('persist')->with($this->isInstanceOf(Article::class));
         $em->expects($this->once())->method('flush');
 
-        $response = $controller->new($this->post(self::VALID_FORM), $auth, $em, $images);
+        $response = $controller->new($this->post(self::VALID_FORM), $auth, $em, $images, $this->makeSanitizer());
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('/admin_articles', $response->getTargetUrl());
@@ -106,7 +108,7 @@ class AdminArticleControllerTest extends TestCase
         [$controller, $auth, $em, $images] = $this->makeController(commissioner: true);
         $em->expects($this->never())->method('persist');
 
-        $controller->new($this->post(['title' => '  '] + self::VALID_FORM), $auth, $em, $images);
+        $controller->new($this->post(['title' => '  '] + self::VALID_FORM), $auth, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('admin/article/form.html.twig', $controller->renderedView);
         $this->assertContains(['error', 'A title is required'], $controller->flashes);
@@ -117,7 +119,7 @@ class AdminArticleControllerTest extends TestCase
         [$controller, $auth, $em, $images] = $this->makeController(commissioner: true);
         $em->expects($this->never())->method('persist');
 
-        $controller->new($this->post(['displayDate' => 'garbage'] + self::VALID_FORM), $auth, $em, $images);
+        $controller->new($this->post(['displayDate' => 'garbage'] + self::VALID_FORM), $auth, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('admin/article/form.html.twig', $controller->renderedView);
         $this->assertContains(['error', 'A valid display date is required'], $controller->flashes);
@@ -136,7 +138,7 @@ class AdminArticleControllerTest extends TestCase
             $persisted = $a;
         });
 
-        $controller->new($this->post(['link' => ''] + self::VALID_FORM, $upload), $auth, $em, $images);
+        $controller->new($this->post(['link' => ''] + self::VALID_FORM, $upload), $auth, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('img/l/abc123', $persisted->getLink());
     }
@@ -147,7 +149,7 @@ class AdminArticleControllerTest extends TestCase
     {
         [$controller, $auth, $em, $images] = $this->makeController(commissioner: false);
 
-        $response = $controller->edit(5, new Request(), $auth, $this->makeRepository(), $em, $images);
+        $response = $controller->edit(5, new Request(), $auth, $this->makeRepository(), $em, $images, $this->makeSanitizer());
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('/', $response->getTargetUrl());
@@ -160,7 +162,7 @@ class AdminArticleControllerTest extends TestCase
         $repo->method('find')->willReturn(null);
 
         $this->expectException(NotFoundHttpException::class);
-        $controller->edit(999, new Request(), $auth, $repo, $em, $images);
+        $controller->edit(999, new Request(), $auth, $repo, $em, $images, $this->makeSanitizer());
     }
 
     public function testEditGetRendersFormWithArticle(): void
@@ -170,7 +172,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, new Request(), $auth, $repo, $em, $images);
+        $controller->edit(5, new Request(), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('admin/article/form.html.twig', $controller->renderedView);
         $this->assertFalse($controller->renderedParams['isNew']);
@@ -186,7 +188,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $response = $controller->edit(5, $this->post(self::VALID_FORM), $auth, $repo, $em, $images);
+        $response = $controller->edit(5, $this->post(self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('/admin_articles', $response->getTargetUrl());
         $this->assertSame('Week 5 Recap', $article->getTitle());
@@ -209,7 +211,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(['author' => '7'] + self::VALID_FORM), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(['author' => '7'] + self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertSame($user, $article->getAuthor());
     }
@@ -225,7 +227,7 @@ class AdminArticleControllerTest extends TestCase
 
         $form = self::VALID_FORM;
         unset($form['active']);
-        $controller->edit(5, $this->post($form), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post($form), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertFalse($article->isActive());
     }
@@ -241,7 +243,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(self::VALID_FORM), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertNotNull($article->getLastEdited());
         $this->assertEqualsWithDelta(time(), $article->getLastEdited()->getTimestamp(), 5);
@@ -256,7 +258,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(self::VALID_FORM), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertNull($article->getLastEdited());
     }
@@ -270,7 +272,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(['title' => ' '] + self::VALID_FORM), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(['title' => ' '] + self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertNull($article->getLastEdited());
     }
@@ -284,7 +286,7 @@ class AdminArticleControllerTest extends TestCase
             $persisted = $a;
         });
 
-        $controller->new($this->post(self::VALID_FORM), $auth, $em, $images);
+        $controller->new($this->post(self::VALID_FORM), $auth, $em, $images, $this->makeSanitizer());
 
         $this->assertNull($persisted->getLastEdited());
     }
@@ -300,7 +302,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(['link' => 'img/l/existinghash'] + self::VALID_FORM), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(['link' => 'img/l/existinghash'] + self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('img/l/existinghash', $article->getLink());
     }
@@ -316,7 +318,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(['link' => 'https://example.com/photo.jpg'] + self::VALID_FORM), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(['link' => 'https://example.com/photo.jpg'] + self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('img/l/rehosted', $article->getLink());
     }
@@ -334,7 +336,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(['link' => 'img/l/oldhash'] + self::VALID_FORM, $upload), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(['link' => 'img/l/oldhash'] + self::VALID_FORM, $upload), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('img/l/uploaded', $article->getLink());
     }
@@ -355,7 +357,8 @@ class AdminArticleControllerTest extends TestCase
             $auth,
             $repo,
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertSame('admin/article/form.html.twig', $controller->renderedView);
@@ -374,7 +377,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->edit(5, $this->post(['link' => 'https://example.com/not-an-image'] + self::VALID_FORM), $auth, $repo, $em, $images);
+        $controller->edit(5, $this->post(['link' => 'https://example.com/not-an-image'] + self::VALID_FORM), $auth, $repo, $em, $images, $this->makeSanitizer());
 
         $this->assertSame('admin/article/form.html.twig', $controller->renderedView);
         $this->assertContains(['error', 'Provide a full URL to a JPEG, GIF or PNG image'], $controller->flashes);
@@ -386,7 +389,7 @@ class AdminArticleControllerTest extends TestCase
     {
         [$controller, $auth, $em] = $this->makeController(commissioner: false);
 
-        $response = $controller->toggle(5, $auth, $this->makeRepository(), $em);
+        $response = $controller->toggle(5, new Request(), $auth, $this->makeRepository(), $em);
 
         $this->assertSame('/', $response->getTargetUrl());
     }
@@ -398,7 +401,7 @@ class AdminArticleControllerTest extends TestCase
         $repo->method('find')->willReturn(null);
 
         $this->expectException(NotFoundHttpException::class);
-        $controller->toggle(999, $auth, $repo, $em);
+        $controller->toggle(999, new Request(), $auth, $repo, $em);
     }
 
     public function testToggleDeactivatesActiveArticle(): void
@@ -411,7 +414,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $response = $controller->toggle(5, $auth, $repo, $em);
+        $response = $controller->toggle(5, new Request(), $auth, $repo, $em);
 
         $this->assertFalse($article->isActive());
         $this->assertSame('/admin_articles', $response->getTargetUrl());
@@ -426,7 +429,7 @@ class AdminArticleControllerTest extends TestCase
         $repo = $this->makeRepository();
         $repo->method('find')->willReturn($article);
 
-        $controller->toggle(5, $auth, $repo, $em);
+        $controller->toggle(5, new Request(), $auth, $repo, $em);
 
         $this->assertTrue($article->isActive());
     }
@@ -436,6 +439,13 @@ class AdminArticleControllerTest extends TestCase
     private function makeController(bool $commissioner): array
     {
         $controller = new class extends AdminArticleController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public ?string $renderedView = null;
             public ?array $renderedParams = null;
             public array $flashes = [];
@@ -475,6 +485,21 @@ class AdminArticleControllerTest extends TestCase
     private function makeRepository(): ArticleRepository
     {
         return $this->createMock(ArticleRepository::class);
+    }
+
+    /**
+     * A real sanitizer configured like config/packages/html_sanitizer.yaml
+     * (app.article), so save-time sanitizing is exercised for real in tests.
+     */
+    private function makeSanitizer(): HtmlSanitizer
+    {
+        return new HtmlSanitizer(
+            (new HtmlSanitizerConfig())
+                ->allowSafeElements()
+                ->allowStaticElements()
+                ->allowRelativeLinks()
+                ->allowRelativeMedias()
+        );
     }
 
     private function post(array $params, ?UploadedFile $upload = null): Request

--- a/symfony-app/tests/Controller/AdminBecomeControllerTest.php
+++ b/symfony-app/tests/Controller/AdminBecomeControllerTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 #[AllowMockObjectsWithoutExpectations]
 class AdminBecomeControllerTest extends TestCase
@@ -74,6 +75,18 @@ class AdminBecomeControllerTest extends TestCase
         $this->assertSame('error', $controller->flashes[0]['type']);
     }
 
+    public function testBecomeAsRejectsInvalidCsrfToken(): void
+    {
+        $user = ['teamid' => 5, 'name' => 'Team X', 'username' => 'teamx', 'userid' => 10];
+        [$controller, $auth, $em] = $this->makeController(commissioner: true, user: $user);
+        $controller->csrfValid = false;
+
+        $auth->expects($this->never())->method('becomeTeam');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->becomeAs(new Request(request: ['teamId' => '5']), $auth, $em);
+    }
+
     // ---- Helpers ----
 
     private Connection $conn;
@@ -81,6 +94,13 @@ class AdminBecomeControllerTest extends TestCase
     private function makeController(bool $commissioner, array|false $user = false): array
     {
         $controller = new class extends AdminBecomeController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public array $flashes = [];
 
             protected function redirectToRoute(string $route, array $parameters = [], int $status = 302): RedirectResponse

--- a/symfony-app/tests/Controller/AdminCommentControllerTest.php
+++ b/symfony-app/tests/Controller/AdminCommentControllerTest.php
@@ -157,6 +157,13 @@ class AdminCommentControllerTest extends TestCase
     private function makeController(bool $commissioner): array
     {
         $controller = new class extends AdminCommentController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public ?string $renderedView = null;
             public ?array $renderedParams = null;
 

--- a/symfony-app/tests/Controller/AdminHeadCoachControllerTest.php
+++ b/symfony-app/tests/Controller/AdminHeadCoachControllerTest.php
@@ -159,6 +159,13 @@ class AdminHeadCoachControllerTest extends TestCase
     private function makeController(bool $commissioner, bool $coachAlreadyOnTeam = false): array
     {
         $controller = new class extends AdminHeadCoachController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public ?string $renderedView = null;
             public ?array $renderedParams = null;
             public array $flashes = [];

--- a/symfony-app/tests/Controller/AdminMoneyControllerTest.php
+++ b/symfony-app/tests/Controller/AdminMoneyControllerTest.php
@@ -157,6 +157,29 @@ class AdminMoneyControllerTest extends TestCase
         $this->assertArrayHasKey('error', $data);
     }
 
+    public function testRecordChangeRejectsMalformedField(): void
+    {
+        [$controller, $auth, $seasonWeek, $em] = $this->makeController(commissioner: true);
+        $em->expects($this->never())->method('find');
+
+        $request = new Request(request: ['field' => 'bogus', 'val' => 'true']);
+        $response = $controller->recordChange($request, $auth, $em);
+
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    public function testRecordChangeReturnsNotFoundForUnknownRecord(): void
+    {
+        [$controller, $auth, $seasonWeek, $em] = $this->makeController(commissioner: true);
+        $em->method('find')->willReturn(null);
+        $em->expects($this->never())->method('flush');
+
+        $request = new Request(request: ['field' => 'paid-999', 'val' => 'true']);
+        $response = $controller->recordChange($request, $auth, $em);
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
     // ---- GET /admin/money/updateFlags ----
 
     public function testUpdateFlagsRedirectsWhenNotCommissioner(): void
@@ -282,6 +305,13 @@ class AdminMoneyControllerTest extends TestCase
     private function makeController(bool $commissioner): array
     {
         $controller = new class extends AdminMoneyController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public ?string $renderedView = null;
             public ?array $renderedParams = null;
 

--- a/symfony-app/tests/Controller/AdminTeamControllerTest.php
+++ b/symfony-app/tests/Controller/AdminTeamControllerTest.php
@@ -94,6 +94,13 @@ class AdminTeamControllerTest extends TestCase
     private function makeController(bool $commissioner): array
     {
         $controller = new class extends AdminTeamController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public ?string $renderedView = null;
             public ?array $renderedParams = null;
 

--- a/symfony-app/tests/Controller/ArticleControllerTest.php
+++ b/symfony-app/tests/Controller/ArticleControllerTest.php
@@ -404,6 +404,13 @@ class ArticleControllerTest extends TestCase
     private function makeController(): ArticleController
     {
         return new class extends ArticleController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public ?string $renderedView = null;
             public ?array $renderedParams = null;
             public array $flashes = [];

--- a/symfony-app/tests/Controller/ArticlePublishControllerTest.php
+++ b/symfony-app/tests/Controller/ArticlePublishControllerTest.php
@@ -11,6 +11,8 @@ use App\Service\AuthenticationService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -153,7 +155,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(false),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertSame('article/publish.html.twig', $controller->renderedView);
@@ -204,7 +207,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertContains(
@@ -230,7 +234,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertSame('article/publish.html.twig', $controller->renderedView);
@@ -249,7 +254,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertCount(3, $controller->flashes);
@@ -269,7 +275,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertContains(
@@ -299,7 +306,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertFalse($persisted->isActive());
@@ -316,6 +324,63 @@ class ArticlePublishControllerTest extends TestCase
         $this->assertStringStartsWith('/article_preview', $response->getTargetUrl());
     }
 
+    public function testSubmitSanitizesBodyAtSaveTime(): void
+    {
+        [$controller, $em, $images] = $this->makeSubmitDeps();
+        $em->method('find')->with(User::class, 7)->willReturn($this->makeUser(7));
+        $images->method('store')->willReturn('img/l/abc123');
+
+        $persisted = null;
+        $em->method('persist')->willReturnCallback(function (Article $a) use (&$persisted) {
+            $persisted = $a;
+        });
+
+        // TinyMCE-style formatting plus an injected script and event handler.
+        $body = '<p style="text-align: center;"><strong>Bold</strong> '
+            . '<span style="color: #ff0000;">red</span></p>'
+            . '<script>alert(1)</script><img src=x onerror="alert(1)">'
+            . '<a href="javascript:alert(1)">x</a>'
+            . str_repeat('More body text to clear the length minimum. ', 6);
+
+        $controller->submit(
+            $this->post(['text' => $body] + self::VALID_FORM),
+            $this->makeAuth(true, userId: 7),
+            $this->makeRepository(),
+            $em,
+            $images,
+            $this->makeSanitizer()
+        );
+
+        $stored = $persisted->getText();
+        // Dangerous markup is gone from what actually gets stored...
+        $this->assertStringNotContainsString('<script', $stored);
+        $this->assertStringNotContainsString('onerror', $stored);
+        $this->assertStringNotContainsString('javascript:', $stored);
+        // ...while the editor's formatting survives.
+        $this->assertStringContainsString('text-align: center', $stored);
+        $this->assertStringContainsString('<strong>Bold</strong>', $stored);
+        $this->assertStringContainsString('color: #ff0000', $stored);
+    }
+
+    public function testSubmitRejectsInvalidCsrfToken(): void
+    {
+        [$controller, $em, $images] = $this->makeSubmitDeps();
+        $controller->csrfValid = false;
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $controller->submit(
+            $this->post(self::VALID_FORM),
+            $this->makeAuth(true, userId: 7),
+            $this->makeRepository(),
+            $em,
+            $images,
+            $this->makeSanitizer()
+        );
+    }
+
     public function testSubmitStoresImageFromUrl(): void
     {
         [$controller, $em, $images] = $this->makeSubmitDeps();
@@ -328,7 +393,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
     }
 
@@ -345,7 +411,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
     }
 
@@ -366,7 +433,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository($draft),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertSame('Week 5 Recap', $draft->getTitle());
@@ -389,7 +457,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository($draft),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertSame('img/l/existing', $draft->getLink());
@@ -410,7 +479,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository($article),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertTrue($article->isActive());
@@ -429,7 +499,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 8),
             $this->makeRepository($draft),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
     }
 
@@ -446,7 +517,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository($draft),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertSame('Old Title', $draft->getTitle());
@@ -628,7 +700,8 @@ class ArticlePublishControllerTest extends TestCase
             $this->makeAuth(true, userId: 7),
             $this->makeRepository(),
             $em,
-            $images
+            $images,
+            $this->makeSanitizer()
         );
 
         $this->assertSame('article/publish.html.twig', $controller->renderedView);
@@ -638,6 +711,13 @@ class ArticlePublishControllerTest extends TestCase
     private function makeController(): ArticlePublishController
     {
         return new class extends ArticlePublishController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
             public ?string $renderedView = null;
             public ?array $renderedParams = null;
             public array $flashes = [];
@@ -669,6 +749,21 @@ class ArticlePublishControllerTest extends TestCase
         $images = $this->createMock(ArticleImageService::class);
 
         return [$controller, $em, $images];
+    }
+
+    /**
+     * A real sanitizer configured like config/packages/html_sanitizer.yaml
+     * (app.article), so save-time sanitizing is exercised for real in tests.
+     */
+    private function makeSanitizer(): HtmlSanitizer
+    {
+        return new HtmlSanitizer(
+            (new HtmlSanitizerConfig())
+                ->allowSafeElements()
+                ->allowStaticElements()
+                ->allowRelativeLinks()
+                ->allowRelativeMedias()
+        );
     }
 
     private function makeAuth(bool $loggedIn, ?int $userId = null, bool $commissioner = false): AuthenticationService

--- a/symfony-app/tests/EventSubscriber/AdminAccessSubscriberTest.php
+++ b/symfony-app/tests/EventSubscriber/AdminAccessSubscriberTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Tests\EventSubscriber;
+
+use App\Controller\Admin\AdminBecomeController;
+use App\Controller\HomeController;
+use App\EventSubscriber\AdminAccessSubscriber;
+use App\Service\AuthenticationService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class AdminAccessSubscriberTest extends TestCase
+{
+    public function testNonCommissionerIsRedirectedFromAdminController(): void
+    {
+        $event = $this->event([new AdminBecomeController(), 'becomeAs']);
+
+        $this->subscriber(commissioner: false)->onController($event);
+
+        // Controller was swapped for a redirect-to-home closure.
+        $response = ($event->getController())();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/', $response->getTargetUrl());
+    }
+
+    public function testCommissionerReachesAdminControllerUnchanged(): void
+    {
+        $original = [new AdminBecomeController(), 'becomeAs'];
+        $event = $this->event($original);
+
+        $this->subscriber(commissioner: true)->onController($event);
+
+        $this->assertSame($original, $event->getController());
+    }
+
+    public function testNonAdminControllerIsUntouchedForNonCommissioner(): void
+    {
+        $original = [new HomeController(), 'index'];
+        $event = $this->event($original);
+
+        $this->subscriber(commissioner: false)->onController($event);
+
+        $this->assertSame($original, $event->getController());
+    }
+
+    public function testSubRequestIsIgnored(): void
+    {
+        $original = [new AdminBecomeController(), 'becomeAs'];
+        $event = $this->event($original, HttpKernelInterface::SUB_REQUEST);
+
+        $this->subscriber(commissioner: false)->onController($event);
+
+        $this->assertSame($original, $event->getController());
+    }
+
+    private function subscriber(bool $commissioner): AdminAccessSubscriber
+    {
+        $auth = $this->createStub(AuthenticationService::class);
+        $auth->method('isCommissioner')->willReturn($commissioner);
+
+        return new AdminAccessSubscriber($auth);
+    }
+
+    private function event(callable $controller, int $type = HttpKernelInterface::MAIN_REQUEST): ControllerEvent
+    {
+        return new ControllerEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $controller,
+            new Request(),
+            $type
+        );
+    }
+}

--- a/symfony-app/tests/Template/ArticleTemplateTest.php
+++ b/symfony-app/tests/Template/ArticleTemplateTest.php
@@ -4,6 +4,10 @@ namespace App\Tests\Template;
 
 use App\Entity\Article;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Bridge\Twig\Extension\HtmlSanitizerExtension;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -19,6 +23,32 @@ class ArticleTemplateTest extends TestCase
     protected function setUp(): void
     {
         $this->twig = new Environment(new FilesystemLoader(__DIR__ . '/../../templates'));
+
+        // Mirror config/packages/html_sanitizer.yaml so the sanitize_html
+        // filter used by _article.html.twig resolves in the bare test env.
+        $sanitizer = new HtmlSanitizer(
+            (new HtmlSanitizerConfig())
+                ->allowSafeElements()
+                ->allowStaticElements()
+                ->allowRelativeLinks()
+                ->allowRelativeMedias()
+        );
+        $sanitizers = new class($sanitizer) implements ContainerInterface {
+            public function __construct(private HtmlSanitizer $sanitizer)
+            {
+            }
+
+            public function get(string $id): HtmlSanitizer
+            {
+                return $this->sanitizer;
+            }
+
+            public function has(string $id): bool
+            {
+                return true;
+            }
+        };
+        $this->twig->addExtension(new HtmlSanitizerExtension($sanitizers));
     }
 
     public function testNeverEditedArticleShowsNoEditedLine(): void


### PR DESCRIPTION
## Summary

Addresses the OWASP findings from the security review of the **Symfony app only** (legacy `/football/` code was out of scope). SQL injection was already clean — every query is parameterized — so this focuses on the remaining Top 10 issues.

- **SSRF (A10)** — `ArticleImageService` now routes remote image URLs through a hardened `fetchRemoteImage()`: http/https only, every resolved A/AAAA address checked against private/reserved ranges, curl pinned to the validated IP (`CURLOPT_RESOLVE`) to block DNS rebinding, redirects refused, size-capped download to a temp file before GD touches it.
- **Stored XSS (A03)** — installed `symfony/html-sanitizer` with an `app.article` sanitizer matching TinyMCE's output. The article body is sanitized both **at save time** (`ArticlePublishController`, `AdminArticleController`) and **at render time** (`sanitize_html` filter), stripping `<script>`/event-handlers/`javascript:` while keeping editor markup.
- **CSRF (A01)** — enabled `framework.csrf_protection`, added a hidden `_token` to every Symfony-handled POST form, and validate it per action: admin actions via `AbstractAdminController::assertCsrfToken()`, public actions inline, and the money AJAX endpoint via `window.moneyCsrfToken` (JSON 403 on mismatch).
- **Secret / dev-mode default (A05)** — rotated the committed `APP_SECRET` out of `.env.dev`, defaulted committed `APP_ENV` to `prod` (dev opts in via gitignored `.env.local`).

## Hardenings
- `AdminAccessSubscriber` centrally guards every `App\Controller\Admin\*` controller, so a new admin controller can't ship without the commissioner check.
- `AdminMoneyController::recordChange` validates the `field` param and null-checks the loaded record (clean 400/404 instead of 500).
- `LegacyBridge` reads an optional `LEGACY_INCLUDE_PATH` env var instead of a hardcoded path.

## Deferred (not in this PR)
- **Finding 5** — unauthenticated `/service/force-stat-reload` shell endpoint. Intentionally held off per discussion.

## Testing
270 tests, 650 assertions — all passing. Security-relevant changed controllers are covered at 94–100%; the SSRF fetch path and `LegacyBridge` were verified manually but don't yet have committed regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)