### PR TITLE
Split illegal/bye-week activation penalties in scoring rules

### DIFF
--- a/symfony-app/migrations/Version20260727010000.php
+++ b/symfony-app/migrations/Version20260727010000.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Backfills the two split activation-penalty keys into every season
+ * row's scoring_rules JSON, restoring the original seed migration's
+ * intent (an explicit per-row snapshot, so future registry default
+ * changes never silently alter historical seasons' math).
+ *
+ * illegal_lineup_penalty was part of that original snapshot (seeded by
+ * Version20260718000000) on every environment except this branch's own
+ * dev database, where an earlier draft of this work stripped it back
+ * out before being reverted. bye_week_lineup_penalty is brand new and
+ * has never been stored anywhere. Both backfills use
+ * JSON_CONTAINS_PATH to only touch rows where the key is genuinely
+ * absent - a stored explicit JSON null means "not awarded that season"
+ * and must not be overwritten, and any environment (stage/prod) that
+ * already has illegal_lineup_penalty must keep whatever value is there
+ * (default or a real historical override) rather than have it
+ * clobbered to the default.
+ */
+final class Version20260727010000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Backfill illegal/bye-week lineup penalty keys into scoring_rules where missing';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE seasons
+            SET scoring_rules = JSON_SET(scoring_rules, '$.illegal_lineup_penalty', 2)
+            WHERE JSON_CONTAINS_PATH(scoring_rules, 'one', '$.illegal_lineup_penalty') = 0
+            SQL);
+
+        $this->addSql(<<<'SQL'
+            UPDATE seasons
+            SET scoring_rules = JSON_SET(scoring_rules, '$.bye_week_lineup_penalty', 2)
+            WHERE JSON_CONTAINS_PATH(scoring_rules, 'one', '$.bye_week_lineup_penalty') = 0
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Only bye_week_lineup_penalty is unambiguously introduced by
+        // this migration everywhere; illegal_lineup_penalty's presence
+        // predates it on most environments, so it's left alone here to
+        // avoid stripping data this migration didn't add.
+        $this->addSql(<<<'SQL'
+            UPDATE seasons
+            SET scoring_rules = JSON_REMOVE(scoring_rules, '$.bye_week_lineup_penalty')
+            SQL);
+    }
+}

--- a/symfony-app/src/Service/ScoreCalculatorService.php
+++ b/symfony-app/src/Service/ScoreCalculatorService.php
@@ -80,15 +80,14 @@ class ScoreCalculatorService
         $def = 0;
         $penalty = 0;
 
-        $illegalPenalty = $rules->int('illegal_lineup_penalty');
         foreach ($rows as $row) {
             if ($row['illegal']) {
-                $penalty += $illegalPenalty;
+                $penalty += $rules->int('illegal_lineup_penalty');
                 continue;
             }
 
             if ($row['kickoff'] === null && $row['pos'] !== 'HC') {
-                $penalty += $illegalPenalty;
+                $penalty += $rules->int('bye_week_lineup_penalty');
                 continue;
             }
 

--- a/symfony-app/src/Service/ScoringRuleRegistry.php
+++ b/symfony-app/src/Service/ScoringRuleRegistry.php
@@ -31,7 +31,8 @@ final class ScoringRuleRegistry
 
     private const DEFINITIONS = [
         // General
-        'illegal_lineup_penalty' => ['group' => 'general', 'type' => 'int', 'default' => 2, 'label' => 'illegal activation penalty', 'help' => 'Team points deducted per illegal or non-playing activation'],
+        'illegal_lineup_penalty' => ['group' => 'general', 'type' => 'int', 'default' => 2, 'label' => 'illegal activation penalty', 'help' => 'Team points deducted per activation not on the roster'],
+        'bye_week_lineup_penalty' => ['group' => 'general', 'type' => 'int', 'default' => 2, 'label' => 'bye-week activation penalty', 'help' => 'Team points deducted per activation on an NFL bye week'],
         'spec_td'                => ['group' => 'general', 'type' => 'int', 'default' => 12, 'label' => 'special team touchdowns'],
         'two_pt'                 => ['group' => 'general', 'type' => 'int', 'default' => 2, 'label' => '2-pt conversions'],
 

--- a/symfony-app/tests/Service/SeasonRuleServiceTest.php
+++ b/symfony-app/tests/Service/SeasonRuleServiceTest.php
@@ -32,6 +32,16 @@ class SeasonRuleServiceTest extends TestCase
         $this->assertSame(9, $rules->int('def_td'));
     }
 
+    public function testIllegalAndByeWeekPenaltiesAreIndependentlyConfigurable(): void
+    {
+        $row = (new Season())->setSeason(2023)->setScoringRules(['bye_week_lineup_penalty' => 1]);
+        $rules = $this->serviceReturning($row)->getScoringRules(2023);
+
+        $this->assertSame(1, $rules->int('bye_week_lineup_penalty'));
+        // illegal_lineup_penalty wasn't overridden, so it keeps the registry default
+        $this->assertSame(2, $rules->int('illegal_lineup_penalty'));
+    }
+
     public function testUnknownStoredKeysAreIgnored(): void
     {
         $row = (new Season())->setSeason(2020)->setScoringRules(['retired_key' => 99]);


### PR DESCRIPTION
## Summary
- `illegal_lineup_penalty` previously covered both an activation not on the roster and one on an NFL bye week, so the two couldn't be tuned independently per season. Adds a sibling `bye_week_lineup_penalty` key to `ScoringRuleRegistry` (same default of 2, per `football/rules/rules2023.php` V.C.3) and has `ScoreCalculatorService` apply each to its own case.
- No schema change needed — `scoring_rules` is JSON and missing keys already fall back to the registry default via `ScoringRules::fromArray`.
- Backfill migration (`Version20260727010000`) writes both keys explicitly into every season row's `scoring_rules`, restoring the original seed migration's snapshot-per-row design so future registry default changes never silently alter historical seasons. Uses `JSON_CONTAINS_PATH` so it only touches rows where a key is genuinely absent — safe to run on stage/prod even if `illegal_lineup_penalty` already exists there, and never clobbers an explicit JSON `null` ("category not awarded that season").

## Test plan
- [x] `vendor/bin/phpunit tests/` — 707 tests, 2141 assertions, all passing
- [x] Verified against the dev DB: all 35 season rows have both keys explicitly stored after the backfill
- [x] Verified the backfill guard preserves an explicit JSON `null` override (simulated on a test row, confirmed excluded, restored)
- [ ] Josh: run the migration on stage/prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)