### PR TITLE
Phase 11: small fixes — proposal formatting, comment badges, login-modal buttons

### DIFF
--- a/specs/2026-07-31-comments-login-polish/plan.md
+++ b/specs/2026-07-31-comments-login-polish/plan.md
@@ -1,0 +1,169 @@
+# Plan — Comment-count badge + login-modal buttons
+
+## 1. `CommentRepository::countByArticleIds()`
+
+- Add to `symfony-app/src/Repository/CommentRepository.php`:
+  ```php
+  /**
+   * Active comment counts for a set of articles, keyed by article id.
+   * Articles with no active comments are absent from the result (caller
+   * treats a missing key as 0).
+   *
+   * @param int[] $articleIds
+   * @return array<int,int>
+   */
+  public function countByArticleIds(array $articleIds): array
+  {
+      if ($articleIds === []) {
+          return [];
+      }
+
+      $rows = $this->em->createQuery(
+          'SELECT c.articleId AS articleId, COUNT(c.id) AS cnt FROM App\Entity\Comment c
+           WHERE c.articleId IN (:ids) AND c.active = 1 GROUP BY c.articleId'
+      )->setParameter('ids', $articleIds)->getResult();
+
+      $counts = [];
+      foreach ($rows as $row) {
+          $counts[(int) $row['articleId']] = (int) $row['cnt'];
+      }
+
+      return $counts;
+  }
+  ```
+- Empty-array short-circuit avoids an `IN ()` DQL error when a page has zero
+  articles.
+
+## 2. Wire counts into `ArticleController::list` and `HomeController::index`
+
+- `ArticleController::list` (`src/Controller/ArticleController.php`): after
+  fetching `$articles = $articles->findActivePage(...)`, compute
+  `$counts = $comments->countByArticleIds(array_map(fn($a) => $a->getId(),
+  $articles))` and add `'counts' => $counts` to the `render()` array.
+  `CommentRepository` needs to be added as a controller argument (it's
+  already injected on `view`/`latest`/`comment`, just not `list`).
+- `HomeController::index` (`src/Controller/HomeController.php`): same
+  pattern — inject `CommentRepository`, compute counts for
+  `$articleRepository->findActivePage(4)`'s ids, add `'counts' => $counts`
+  to the render array.
+
+## 3. `_card.html.twig` badge
+
+- In `templates/article/_card.html.twig`, inside `.card-body` near the
+  date/author `<p>`, add:
+  ```twig
+  {% set commentCount = counts[article.id] ?? 0 %}
+  <span class="badge badge-secondary">💬 {{ commentCount }}</span>
+  ```
+  Relies on `counts` being present in whichever parent template's context
+  the include runs in (`list.html.twig` loop context, or
+  `home/index.html.twig`'s two include call sites) — no change needed to
+  either template's `include()` calls themselves, since Twig `include()`
+  inherits the calling template's full context by default.
+
+## 4. Repository + controller tests
+
+- `tests/Repository/CommentRepositoryTest.php`: add
+  `testCountByArticleIdsCountsOnlyActiveComments` — fixture with one article
+  having 2 active + 1 inactive comment and another article with 0 comments;
+  assert the result map has the first article's id → 2 and the second is
+  absent (or maps to 0 via `?? 0` at the call site).
+- `tests/Controller/ArticleControllerTest.php`: extend (or add) a
+  list-page test asserting the rendered page contains a `badge` with the
+  expected count for a fixture article with active comments, and also
+  shows a "💬 0" badge for a fixture article with zero active comments.
+- `tests/Controller/HomeControllerTest.php`: same style assertion for the
+  homepage's article cards.
+
+## 5. `_login_required.html.twig` partial
+
+- New `symfony-app/templates/_login_required.html.twig`:
+  ```twig
+  <div class="text-center font-weight-bold h4 my-3">
+      {{ message }}
+      <div class="mt-2">
+          <button type="button" class="btn btn-wmffl" data-toggle="modal" data-target="#loginModal">Log In</button>
+      </div>
+  </div>
+  ```
+  Same `data-toggle`/`data-target` pair as the navbar button
+  (`base.html.twig:83`) — no JS or modal-markup changes needed.
+
+## 6. Swap in the ten call sites
+
+Each site's existing logged-out condition is unchanged; only the branch
+contents change to an include of the new partial with that page's existing
+message text:
+
+- `templates/transactions/protections_saved.html.twig:10-13` — only the
+  `error == 'not_logged_in'` branch changes (leave the `deadline`/`unpaid`/
+  `over_budget` `alert-secondary` branches as-is):
+  ```twig
+  {% if error == 'not_logged_in' %}
+      {{ include('_login_required.html.twig', {message: 'You must be logged in to save protections.'}) }}
+  ```
+- `templates/transactions/protections.html.twig:9-10` — message "You must be
+  logged in to submit protections"
+- `templates/transactions/ir.html.twig:15-16` — condition stays
+  `{% if eligible is null %}`; message "You must be logged in to use this
+  feature"
+- `templates/transactions/list.html.twig:11-12` — message "You must be
+  logged in to use this feature"
+- `templates/transactions/confirm.html.twig:10-11` — message "You must be
+  logged in to perform transactions"
+- `templates/draftdate/index.html.twig:9-10` — message "You must be logged
+  in to use this feature"
+- `templates/proposals/ballot.html.twig:9-10` — message "You must be logged
+  in to cast your votes."
+- `templates/proposals/submit.html.twig:16-17` — message "You must be
+  logged in to submit rule proposals."
+- `templates/trades/index.html.twig:11-12` — message "You must be logged in
+  to use this feature"
+- `templates/article/publish.html.twig:15-16` — message "You must be logged
+  in to use this feature"
+
+## 7. Controller test coverage for the button
+
+For each of the ten pages, find the existing logged-out-state test in its
+controller's test file (most already assert the plain message text) and
+extend the assertion to also check for the login-trigger markup (e.g.
+`data-target="#loginModal"` or `btn-wmffl` + `Log In` inside the response
+body). Where a controller test file has no logged-out case today, add one.
+Controllers/tests to touch:
+- `ProtectionsController` → `tests/Controller/ProtectionsControllerTest.php`
+  (covers both `protections.html.twig` and `protections_saved.html.twig`)
+- `InjuredReserveController` → `tests/Controller/InjuredReserveControllerTest.php`
+- `RosterMoveController` → `tests/Controller/RosterMoveControllerTest.php`
+  (covers both `list.html.twig` and `confirm.html.twig`)
+- `DraftDateController` → `tests/Controller/DraftDateControllerTest.php`
+  (new file if none exists for the member-facing controller — only the
+  admin variant has a test today)
+- `BallotController` → add/extend in a `BallotControllerTest.php` if one
+  doesn't already cover the logged-out case, else extend
+  `ProposalControllerTest.php` if ballot assertions live there
+- `ProposalController` (`/rules/proposals/submit`) →
+  `tests/Controller/ProposalControllerTest.php`
+- `TradeController` → `tests/Controller/TradeControllerTest.php`
+- `ArticlePublishController` → `tests/Controller/ArticlePublishControllerTest.php`
+
+## 8. Manual verification
+
+- Visit `/articles` and `/` logged out and logged in; confirm badges show
+  the right counts (cross-check against `/article/{id}`'s visible comment
+  thread count) and are absent on articles with zero active comments.
+- Visit each of the ten gated pages logged out; confirm the message +
+  "Log In" button render, clicking the button opens the same modal as the
+  navbar button, and a successful login reloads into the originally
+  intended page (existing `submitContactForm()` behavior — confirm it's
+  unaffected).
+- Trigger `ArticleController::comment` logged out (POST to
+  `/article/{id}/comment` while logged out, or find the UI path if the
+  comment form itself is gated) and confirm the flash renders on
+  `article/view.html.twig` with the navbar's "Log In" button visible on the
+  same page — no code change here, verification only.
+
+## 9. Run full test suite
+
+- `cd symfony-app && vendor/bin/phpunit tests/` — confirm all tests pass,
+  no regressions against the post-items-1–2 baseline (793 tests, per
+  `specs/roadmap.md`'s Phase 11 `Done` entry).

--- a/specs/2026-07-31-comments-login-polish/requirements.md
+++ b/specs/2026-07-31-comments-login-polish/requirements.md
@@ -1,0 +1,117 @@
+# Requirements — Comment-count badge + login-modal buttons (Phase 11, items 3 & 4)
+
+## Scope
+
+The last two items in `specs/roadmap.md` Phase 11 ("Small fixes"). Independent
+of each other but small enough to land together as one PR on
+`phase11-proposals-formatting`, continuing after items 1–2
+(`specs/2026-07-31-proposals-formatting/`).
+
+1. **Article cards — comment count indicator.** `templates/article/_card.html.twig`
+   (used by `article/list.html.twig` and `home/index.html.twig`) shows
+   title/date/author only, no hint of discussion activity. Add a comment-count
+   badge sourced from `Comment` (`active = 1` rows only).
+
+2. **Login form alongside "must be logged in" messages.** Ten gated pages show
+   a plain logged-out message with no way to log in right there, even though a
+   global login modal (`#loginModal`, `templates/base.html.twig:88-117`,
+   opened today only by the navbar "Log In" button at `base.html.twig:83`)
+   already exists on every page. Add a "Log In" button next to each message
+   that opens the same modal, via one shared partial.
+
+## Decisions
+
+### Item 3 — comment count
+
+- **Query**: add `CommentRepository::countByArticleIds(array $articleIds):
+  array<int,int>` — one batch query (`GROUP BY article_id`, `WHERE active =
+  1`), returning `[articleId => count]`, keyed only for articles that have at
+  least one active comment (missing key = 0). Avoids N+1 across a page of
+  cards. No new single-article `countByArticle` method — nothing calls
+  `_card.html.twig` for a single article outside a list context.
+- **Wiring**: `ArticleController::list` and `HomeController::index` each call
+  `countByArticleIds()` once with the ids of the articles they're about to
+  render, and add the resulting map to their `render()` array as `counts`.
+  `_card.html.twig` reads `counts[article.id] ?? 0` directly — it relies on
+  Twig's `include()` inheriting the calling template's full context by
+  default (already the pattern `home/index.html.twig` uses for its bare
+  `include('article/_card.html.twig')` calls in the loop), so neither
+  template's existing `include()` call sites need to change.
+- **Badge markup**: a small Bootstrap 4 badge (`<span class="badge
+  badge-secondary">💬 {{ count }}</span>`, matching the `badge-secondary`/
+  `badge-warning`/`badge-success` usage already in
+  `templates/admin/proposals/index.html.twig`), placed in the card body near
+  the date/author line.
+- **Zero comments**: badge always shows, including "💬 0" — every card gets
+  a consistent discussion-activity indicator regardless of count.
+- **No entity/migration changes.** `Comment.articleId` is a plain int column
+  already; the new repository method is a read-only aggregate query.
+
+### Item 4 — login button next to gated messages
+
+- **Shared partial**: new `templates/_login_required.html.twig`, taking a
+  `message` variable. Renders a standardized block: the message text plus a
+  `btn-wmffl` "Log In" button with `data-toggle="modal" data-target=
+  "#loginModal"` (identical trigger attributes to the navbar button at
+  `base.html.twig:83`, so no JS changes are needed — the existing modal
+  markup and `submitContactForm()` handler in `base.html.twig` are reused
+  as-is).
+- **Standardize appearance**: all ten call sites render through the same
+  partial markup (`text-center font-weight-bold h4` message + centered
+  button below it), replacing whatever ad hoc wrapper (`div`/`p`,
+  with/without `font-weight-bold`/`h4`) each page uses today. This is a
+  deliberate small visual convergence, not just a button bolt-on.
+- **Call sites** (10): each keeps its own existing logged-out condition
+  (`{% if not loggedIn %}`, `{% if not isLoggedIn %}`,
+  `{% if eligible is null %}` in `ir.html.twig`) and only the *contents* of
+  that branch change to `{{ include('_login_required.html.twig', {message:
+  '...'}) }}`:
+  - `templates/transactions/protections_saved.html.twig:10-13` (`error ==
+    'not_logged_in'` branch — the other three `error` branches
+    (`deadline`/`unpaid`/`over_budget`) are untouched, they stay as their own
+    `alert-secondary` boxes since those aren't login-related)
+  - `templates/transactions/protections.html.twig:9-10`
+  - `templates/transactions/ir.html.twig:15-16`
+  - `templates/transactions/list.html.twig:11-12`
+  - `templates/transactions/confirm.html.twig:10-11`
+  - `templates/draftdate/index.html.twig:9-10`
+  - `templates/proposals/ballot.html.twig:9-10`
+  - `templates/proposals/submit.html.twig:16-17`
+  - `templates/trades/index.html.twig:11-12`
+  - `templates/article/publish.html.twig:15-16`
+- **`ArticleController::addComment` flash** (`src/Controller/ArticleController.php:83`,
+  actually the `comment()` action): verification only, no code change
+  expected. The "You must be logged in to comment" flash renders via the
+  generic `app.flashes('error')` loop already in
+  `templates/article/view.html.twig:7-9` (a shared `alert-danger` box used
+  for several error flashes on that page, not login-specific — it should
+  NOT be swapped for the new partial). The redirect target
+  (`article_view`) is a normal page with the navbar's own "Log In" button
+  already visible, so the trigger requirement is already met; confirm this
+  during manual verification rather than changing code.
+
+## Out of scope
+
+- Phase 12+ items (quicklinks drag-and-drop, admin config editor, error
+  handling, activations UI, etc.) — separate phases.
+- Any change to `Comment`/`CommentRepository`'s existing methods
+  (`findActiveByArticle`, `findThreadByArticle`, `findPageForAdmin`).
+- Any change to the login modal's own markup or `submitContactForm()` JS in
+  `base.html.twig` — reused as-is.
+- Replacing the generic error-flash box on `article/view.html.twig` with the
+  new login partial (see decision above).
+
+## Context
+
+- Branch: `phase11-proposals-formatting` (continuing after
+  `specs/2026-07-31-proposals-formatting/`)
+- Relevant files:
+  - `symfony-app/src/Repository/CommentRepository.php`
+  - `symfony-app/src/Controller/ArticleController.php`
+  - `symfony-app/src/Controller/HomeController.php`
+  - `symfony-app/templates/article/_card.html.twig`
+  - `symfony-app/templates/_login_required.html.twig` (new)
+  - The ten templates listed above
+  - `symfony-app/tests/Repository/CommentRepositoryTest.php`
+  - `symfony-app/tests/Controller/ArticleControllerTest.php`
+  - `symfony-app/tests/Controller/HomeControllerTest.php`

--- a/specs/2026-07-31-comments-login-polish/validation.md
+++ b/specs/2026-07-31-comments-login-polish/validation.md
@@ -1,0 +1,47 @@
+# Validation — Comment-count badge + login-modal buttons
+
+Implementation is done and mergeable when all of the following hold.
+
+## Automated tests
+
+- [ ] `cd symfony-app && vendor/bin/phpunit tests/` passes in full, no
+      regressions (baseline: 793 tests green as of Phase 11 items 1–2).
+- [ ] `CommentRepositoryTest::testCountByArticleIdsCountsOnlyActiveComments`
+      (or equivalent) passes: only `active = 1` comments counted, articles
+      with zero active comments absent from the returned map.
+- [ ] `ArticleControllerTest` and `HomeControllerTest` cases pass: rendered
+      `/articles` and `/` pages show a comment-count badge with the correct
+      number for an article with active comments, and a "💬 0" badge for an
+      article with zero.
+- [ ] Each of the ten controller test files listed in `plan.md` §7 has a
+      logged-out-state test asserting the response contains the login
+      trigger (`data-target="#loginModal"` or equivalent), not just the
+      bare message text.
+
+## Manual verification
+
+- [ ] `/articles` (list page) and `/` (homepage) show correct, matching
+      comment-count badges per article, including "💬 0" for zero-comment
+      articles.
+- [ ] Each of the ten gated pages, visited while logged out, shows its
+      message with a "Log In" button next to it; clicking the button opens
+      the same modal as the navbar's "Log In" button (no separate modal
+      instance, no JS console errors).
+- [ ] Logging in via that modal from one of the ten gated pages behaves the
+      same as logging in via the navbar button (page reloads showing the
+      now-logged-in content) — confirms no regression to
+      `submitContactForm()`.
+- [ ] `protections_saved.html.twig`'s other three error states (`deadline`,
+      `unpaid`, `over_budget`) still render their original `alert-secondary`
+      boxes unchanged — only the `not_logged_in` case changed.
+- [ ] `article/view.html.twig`'s "You must be logged in to comment" flash
+      (triggered by posting a comment while logged out) still renders in
+      its existing generic error-flash box, with the navbar's "Log In"
+      button visibly available on the same page — confirmed as sufficient,
+      no code change made there.
+
+## Not required for merge
+
+- No migration to run (no schema change — `Comment.articleId` unchanged).
+- No deploy-time data fix needed (repository/controller/template-only
+  change).

--- a/specs/2026-07-31-proposals-formatting/plan.md
+++ b/specs/2026-07-31-proposals-formatting/plan.md
@@ -1,0 +1,109 @@
+# Plan — Proposals formatting fixes
+
+## 1. `MarkdownService` — soft breaks + indentation
+
+- In `MarkdownService::__construct`, add `'renderer' => ['soft_break' =>
+  "<br>\n"]` to the `CommonMarkConverter` config array (alongside the
+  existing `html_input`/`allow_unsafe_links` keys).
+- Add a private normalization step in `toHtml()`, run on the input before
+  `$this->converter->convert()`:
+  - Split on `\n`.
+  - For each line, replace leading run of spaces/tabs with `&nbsp;` per
+    space and `&nbsp;&nbsp;&nbsp;&nbsp;` per tab, preserving order (e.g. a
+    line starting with `\t  ` becomes 4+2 = 6 `&nbsp;`s), then keep the
+    rest of the line unchanged.
+  - Rejoin with `\n`.
+  - This must run on the *raw Markdown* (not HTML) since `html_input =>
+    escape` will otherwise escape a literal `&nbsp;` — confirm behavior
+    with a test; CommonMark's HTML-entity handling of raw `&nbsp;` in
+    Markdown source needs verification (test #1 below) since
+    `html_input => escape` escapes actual `<`/`>`/HTML tags but is not
+    expected to affect a bare entity reference — check the rendered output
+    is `&nbsp;` → U+00A0 in the browser, not a literal escaped ampersand.
+    If `escape` mode does mangle the entity, use the same placeholder
+    trick `ProposalPageParser::toMarkdown()` uses (swap `&nbsp;` for a
+    plain-text token, convert, swap back) instead of emitting `&nbsp;`
+    pre-conversion.
+
+## 2. `MarkdownService` tests
+
+Add to `MarkdownServiceTest`:
+- `testSingleNewlineRendersAsLineBreak` — two-line input with a single
+  `\n` between them renders with a `<br>` between the two lines' content
+  (not collapsed to a space).
+- `testLeadingSpacesPreserveIndentation` — a line with leading spaces
+  (e.g. `"  nested item"`) renders with `&nbsp;` (not a `<pre><code>`
+  block, confirming the 4-space indented-code-block trap is avoided).
+- `testLeadingTabPreservesIndentation` — a leading tab renders as four
+  `&nbsp;`s.
+- `testImportedHardBreakStyleUnaffected` — feed in a hard-break-style
+  input (`"line one  \nline two"`, i.e. trailing double-space before the
+  newline, matching what `ProposalPageParser` produces) and confirm it
+  still renders `<br>` between the lines (regression guard: this already
+  passed before the change since hard breaks are a Markdown default,
+  confirm the new soft_break option doesn't double up or otherwise change
+  that output).
+- Keep all existing tests green, particularly
+  `testMultiLevelBlockquoteRendersNestedQuotesWithoutRawHtml` (nested
+  blockquotes/lists must still render correctly with the new options).
+
+## 3. Client-side preview parity (`submit.html.twig`)
+
+- Update `miniMarkdown()` in the `<script>` block:
+  - Add a leading-whitespace-to-`&nbsp;`-run step per line (mirroring the
+    server), applied after `escapeHtml()` but before the existing
+    bold/italic/link/list/blockquote regex passes — same
+    space-per-space/tab-as-four-spaces rule as the server.
+  - Existing per-line `<p>` wrapping already produces one visual break per
+    typed line, which is the visual behavior the server-side `soft_break`
+    change is matching — no change needed there, just confirm by manual
+    test in step 5.
+
+## 4. `list.html.twig` — show Rationale, not Description
+
+- In `symfony-app/templates/proposals/list.html.twig`, delete the block:
+  ```twig
+  {% if issue.description %}
+      <p>{{ issue.description }}</p>
+  {% endif %}
+  ```
+- Leave the `rationale` and `ruleChangeText` blocks immediately below it
+  unchanged.
+
+## 5. `ballot.html.twig` — confirm Description-only (no code change expected)
+
+- Read `templates/proposals/ballot.html.twig` and confirm the card body
+  shows only `issue.description`, with no `rationale`/`ruleChangeText`
+  reference. It already does as of Phase 10.6 — this step is a
+  verification, not an edit. If it turns out to show more than
+  `description`, trim it down to match.
+
+## 6. Controller test coverage
+
+In `symfony-app/tests/Controller/ProposalControllerTest.php` (or a new
+test if the existing file doesn't cover rendering assertions well), add:
+- A proposals-list test asserting the rendered page contains the
+  rationale text and does NOT contain the raw description text for a
+  fixture issue that has both fields set differently.
+- A ballot test (if not already covered) asserting the ballot page shows
+  `description` and does not contain rationale/rule-change text for a
+  fixture issue that has both.
+
+## 7. Manual verification
+
+- Run the dev server (`symfony-app/bin/console server:start` or
+  equivalent per `run` skill), log in as a member, visit
+  `/rules/proposals/submit`, type a rationale with multiple lines and an
+  indented sub-item, confirm the live preview shows line breaks and
+  indentation matching the eventual saved/rendered output.
+- Visit `/rules/proposals` for a season containing the imported 2025.1
+  content (per `specs/2026-07-27-rule-proposals-issues/`) and confirm it
+  renders identically to before this change (screenshot or manual diff of
+  the relevant card).
+- Visit `/rules/ballot` and confirm cards show only the short description.
+
+## 8. Run full test suite
+
+- `cd symfony-app && vendor/bin/phpunit tests/` — confirm all tests pass,
+  including the new ones, with no regressions in the 781-test baseline
+  noted in `specs/2026-07-27-rule-proposals-issues/`.

--- a/specs/2026-07-31-proposals-formatting/requirements.md
+++ b/specs/2026-07-31-proposals-formatting/requirements.md
@@ -1,0 +1,81 @@
+# Requirements — Proposals formatting fixes (Phase 11, items 1 & 2)
+
+## Scope
+
+Two small, self-contained fixes from `specs/roadmap.md` Phase 11 ("Small
+fixes"), both touching the rule-proposals feature landed in Phase 10.6.
+Land together as one PR.
+
+1. **Proposal Markdown authoring — line breaks and indentation.**
+   `MarkdownService` (`symfony-app/src/Service/MarkdownService.php`) renders
+   member/admin-authored `Rationale` and `RuleChangeText` with CommonMark
+   defaults, which collapse a single typed newline into a soft break (a
+   space) and drop leading-space indentation. The historical proposals
+   imported by `app:backfill-proposals` don't hit this problem — the
+   importer (`ProposalPageParser`) already emits proper Markdown hard
+   breaks (`"  \n"`, i.e. trailing double-space) for `<br>` and `&nbsp;`
+   runs for indentation, both of which CommonMark already renders
+   correctly. But proposals *typed directly* into the submit/admin forms
+   have no such transformation — a member pressing Enter between lines
+   gets them squashed together on the rendered page, which doesn't match
+   how the imported (Phase 10.6) content displays.
+
+2. **Proposal vs. ballot field visibility.**
+   `templates/proposals/list.html.twig` and `templates/proposals/ballot.html.twig`
+   currently overlap in what they show. Split them:
+   - `list.html.twig` should show `Rationale`, not the short `Description`.
+   - `ballot.html.twig` already shows only `Description` (no rationale/rule
+     change) — no code change needed there, just confirm via a test.
+
+## Decisions
+
+- **soft_break config**: set CommonMark's `renderer.soft_break` option to
+  `"<br>\n"` so every single `\n` becomes a line break. This changes
+  soft-break rendering only; existing imported content uses hard breaks
+  (two trailing spaces) which render as `<br>` under CommonMark defaults
+  already, so this option is additive and shouldn't change imported output.
+- **Indentation**: normalize leading whitespace on each line to `&nbsp;`
+  before handing text to the converter (space → `&nbsp;`, tab → four
+  `&nbsp;`s), matching the encoding already used by the backfill importer
+  (`ProposalPageParser::toMarkdown`) so both paths produce the same kind of
+  indentation-preserving HTML. This also sidesteps CommonMark's 4-space
+  indented-code-block rule, which would otherwise turn indented text into a
+  `<pre><code>` block instead of a plain indented paragraph.
+- **Where this applies**: only `MarkdownService::toHtml()` — it renders
+  exactly two fields (`Rationale`, `RuleChangeText`) on exactly two
+  surfaces (member submit form preview via `/rules/proposals/submit`,
+  admin edit form via `/admin/proposals`), both flowing through
+  `markdown_to_html` on `list.html.twig`. Blast radius is contained to
+  that one service; no other Markdown rendering exists in the app.
+- **Client-side preview**: `templates/proposals/submit.html.twig`'s
+  `miniMarkdown()` JS must match the new server behavior — currently it
+  turns every line into its own `<p>`, which already behaves like a hard
+  line break, but the indentation stripping needs a matching change (see
+  plan) so what the member sees while typing matches what's saved.
+- **list.html.twig change**: drop the
+  `{% if issue.description %}<p>{{ issue.description }}</p>{% endif %}`
+  block; keep the existing `rationale` and `ruleChangeText` blocks as-is.
+- **No entity/migration changes.** Both fixes are template/service-level;
+  `Issue` entity fields (`description`, `rationale`, `ruleChangeText`) are
+  unchanged.
+
+## Out of scope
+
+- Phase 11 items 3 (article comment-count badge) and 4 (login-modal
+  buttons) — deferred to a separate spec/PR per the scoping decision for
+  this branch.
+- Any change to the admin proposal form's lack of a live preview (it has
+  none today, and none is being added).
+- Any change to how the backfill importer (`ProposalPageParser`) encodes
+  Markdown — it's already correct for this problem and is out of scope.
+
+## Context
+
+- Branch: `phase11-proposals-formatting`
+- Relevant files:
+  - `symfony-app/src/Service/MarkdownService.php`
+  - `symfony-app/tests/Service/MarkdownServiceTest.php`
+  - `symfony-app/templates/proposals/list.html.twig`
+  - `symfony-app/templates/proposals/ballot.html.twig`
+  - `symfony-app/templates/proposals/submit.html.twig` (client preview JS)
+  - `symfony-app/tests/Controller/ProposalControllerTest.php`

--- a/specs/2026-07-31-proposals-formatting/validation.md
+++ b/specs/2026-07-31-proposals-formatting/validation.md
@@ -1,0 +1,44 @@
+# Validation — Proposals formatting fixes
+
+Implementation is done and mergeable when all of the following hold.
+
+## Automated tests
+
+- [ ] `cd symfony-app && vendor/bin/phpunit tests/` passes in full, no
+      regressions (baseline: 781 tests green as of Phase 10.6).
+- [ ] New `MarkdownServiceTest` cases pass:
+  - single newline → `<br>` (soft break no longer collapses to a space)
+  - leading spaces → `&nbsp;`-preserved indentation, no `<pre><code>`
+    block
+  - leading tab → four `&nbsp;`s
+  - hard-break-style input (trailing double-space, matching
+    `ProposalPageParser` output) still renders `<br>` — unaffected by the
+    soft_break change
+  - existing nested-blockquote/list test still passes unchanged
+- [ ] New/updated `ProposalControllerTest` (or equivalent) cases pass:
+  - `/rules/proposals` list shows rationale text, not the short
+    description, for a fixture issue with both set
+  - `/rules/ballot` shows only the short description, not
+    rationale/rule-change text
+
+## Manual verification
+
+- [ ] On `/rules/proposals/submit`, typing a multi-line rationale with an
+      indented sub-item shows matching line breaks and indentation in the
+      live preview.
+- [ ] Submitting that proposal (or an admin edit via `/admin/proposals`)
+      and viewing it on `/rules/proposals` shows the same line breaks and
+      indentation as the preview.
+- [ ] The imported 2025.1 proposal content (from
+      `specs/2026-07-27-rule-proposals-issues/`) on `/rules/proposals`
+      renders identically to its pre-change appearance — no regression
+      from the `soft_break`/indentation change for hard-break-style
+      imported content.
+- [ ] `/rules/proposals` no longer shows the short `Description` field
+      anywhere; `/rules/ballot` shows only the short `Description` and
+      nothing else per item.
+
+## Not required for merge
+
+- No migration to run (no schema change).
+- No deploy-time data fix needed (template/service-only change).

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -164,7 +164,7 @@ should be small enough to land as its own PR.
   `draftdate.php`, `common/processdraftdate.php`, and the 16
   per-season `processdraftdate.php` copies deleted, no redirects
   (only archival newsletter links pointed at them).
-- Season Rules foundation (pre-Phase-11/12, 2026-07-18,
+- Season Rules foundation (pre-Phase-14/15, 2026-07-18,
   `specs/2026-07-18-season-rules/`). Per-season league rules moved
   from hardcoded constants to a `seasons` table (`Season` entity):
   typed structure/finance columns + `scoring_rules` JSON +
@@ -174,7 +174,7 @@ should be small enough to land as its own PR.
   parameter once (drives DTOs, the admin form and scorer labels);
   `SeasonRuleService` (cached, missing-row-safe) feeds
   `PlayerScorerService` — the single scoring engine, emitting labeled
-  `ScoreLine[]` for Phase 13 box scores, golden-tested equivalent to
+  `ScoreLine[]` for Phase 16 box scores, golden-tested equivalent to
   legacy `scoring.php` over all 451k stat rows (and fixing the old
   Symfony recalc's OL strict-compare bug). ScoreCalculatorService,
   TeamMoneyService (constants deleted), the six `week<=14` hardcodes
@@ -204,46 +204,210 @@ should be small enough to land as its own PR.
   via a forced error producing a new dated file without touching the
   legacy file; prod write-access/rotation verification is Josh's
   post-deploy step.
+- Rule proposals (Phase 10.6 complete, 2026-07-27,
+  `specs/2026-07-27-rule-proposals-issues/`, PR #54): `issues` redesigned
+  and the full member/admin/ballot UI built. The original plan was
+  data-layer-only prep for the Phase 17 `rules` item; the delivered scope
+  went further, replacing the hand-written `proposals{year}.php` pages
+  outright. Migration `Version20260727020000`: widened `IssueName`, added
+  `Rationale`/`RuleChangeText`/`Published` + a `Status` enum
+  (Open/Passed/Rejected/Withdrawn, backfilled from the legacy `Result`),
+  dropped legacy `Sponsor`/`Result`; new `issue_sponsors` ordered
+  co-sponsor join; `seasons` proposal pass/fail thresholds (.67 pre-2022,
+  .51 from 2022); `ballot` FK integrity. Member: `/rules/proposals`
+  season-by-season list (CommonMark-rendered), `/rules/proposals/submit`
+  (pending issue + commissioner email), `/rules/ballot` voting with
+  per-season thresholds (injection-safe writes). Admin: `/admin/proposals`
+  CRUD/approve/withdraw/put-on-ballot with in-place co-sponsor
+  reconciliation (fixes an `IssueSponsor` identity-collision on edit) and a
+  For-Against-Abstain-NoVote tally column for decided proposals;
+  `AdminBallotController` reduced to a read-only tally; season-threshold
+  editing on `/admin/seasons`. `MarkdownService` (CommonMark,
+  `html_input => escape`) + `markdown_to_html` Twig filter;
+  `ProposalPageParser` preserves `<br>` line breaks and `&nbsp;`
+  indentation and strips block-spanning italics. Historical backfill:
+  `app:backfill-proposals` parses the archived pages into idempotent SQL
+  (38 inserts / 149 enriched / 0 unresolved / 0 conflicts); the 27
+  `proposals{year}.php` pages moved to `archive/proposals/` (the command's
+  default input); legacy `propose*`/`ballot*` stubs deleted and
+  301-redirected (`LegacyRulesRedirectController`). Deploy: run migration
+  `Version20260727020000`, then apply
+  `scripts/database/migration/2026-07-27-issues-backfill.sql` (regenerate
+  per-env recommended), then confirm `MAILER_DSN` in prod `.env.local`.
 
-## Phase 10.6 — Rule proposals: `issues` table redesign
+## Phase 11 — Small fixes
 
-Current state (found 2026-07-25 comparing `football/rules/proposals{year}.php`
-against the `issues` table): `issues` (`IssueID, IssueNum, IssueName
-varchar(40), Sponsor int, Description tinytext, Season, Deadline, StartDate,
-Result varchar(10)`) backs the ballot/voting flow but was never rich enough
-to reproduce what the legacy pages actually display. `Sponsor` is a single
-int and can't hold co-sponsors (e.g. "Tom Marsh and Josh Utterback",
-"Tom Marsh and Mike Atlas"); `Description` is a short paraphrase, not the
-full rationale prose shown on the page; there's no column at all for the
-proposed rule-change text (today only a hand-written `<blockquote><i>`
-block, sometimes multi-level); `Result` is a free `varchar(10)` with
-inconsistent historical values (`PASS`/`Passed`/`REJECT`/`REJECTED`/a stray
-typo). This phase is forward-looking only — no historical proposal data
-migration.
+A catch-all phase for small, self-contained fixes and polish that don't
+warrant their own feature phase. Batched here so each can land as a small
+PR (or a few together) rather than blocking on a larger effort.
 
-1. Migration: widen `IssueName` to `varchar(120)`; add `Rationale text`
-   (full prose, alongside the existing short `Description`); add
-   `RuleChangeText text` (markdown); replace `Result varchar(10)` with
-   `Status enum('Open','Passed','Rejected','Withdrawn')`; drop `Sponsor int`
-2. New `issue_sponsors` table (`IssueID` FK, `UserID` FK, `SortOrder`)
-   replacing the single `Sponsor` column — supports any number of
-   co-sponsors, ordered for display
-3. `league/commonmark` to render `RuleChangeText` (and `Rationale` if it
-   also ends up markdown) to HTML — `html_input => escape` since proposal
-   authors aren't admin-only; small service + Twig filter
-   (`|markdown_to_html|raw`)
-4. `ballot` table stays as-is structurally (vote tallies stay derived via
-   `GROUP BY Vote`, not duplicated into `Status`), but currently has no FK
-   constraints at all (`PRIMARY KEY (IssueID, TeamID)` only) — add
-   `FK_ballot_issue` (`IssueID` → `issues.IssueID`) and `FK_ballot_team`
-   (`TeamID` → `team.TeamID`)
-5. Explicitly out of scope: cross-reference/supersession links between
-   issues, and role-label sponsors (e.g. "Commissioner")
-6. The actual Symfony controller/templates for submitting and displaying
-   proposals are Phase 14's `rules` item — this phase is data-layer prep
-   for that work, not a UI port
+1. **Proposal Markdown authoring — line breaks and indentation.** New
+   proposals typed into the admin/member Markdown fields (`Rationale`,
+   `RuleChangeText`) swallow single newlines and drop leading-space
+   indentation, so they don't match the imported historical proposals
+   (whose stored Markdown carries hard breaks and `&nbsp;` runs). Fix
+   `MarkdownService` so authored text renders the way it's typed:
+   - set the CommonMark renderer option `soft_break => "<br>\n"` so every
+     newline becomes a line break (a lone `\n` is otherwise a soft break
+     the browser collapses to a space);
+   - normalize leading whitespace to `&nbsp;` before rendering (each space
+     → one `&nbsp;`, tab → four) so typed indentation survives — CommonMark
+     decodes `&nbsp;` to U+00A0, which isn't collapsed, and this also
+     sidesteps the 4-leading-space indented-code-block trap.
+   Update the submit-form live-preview JS to match the server rendering,
+   add tests, and confirm the imported 2025.1 content still renders
+   identically. Blast radius is just the two proposal fields —
+   `MarkdownService` renders nothing else.
 
-## Phase 11 — Activations UI modernization
+2. **Proposal vs. ballot field visibility.** The two views currently show
+   the same fields; they should be split so each shows only what's
+   relevant to its purpose:
+   - Proposals page (`templates/proposals/list.html.twig`): show
+     `Rationale`, not `Description` (the short description) — drop the
+     `{% if issue.description %}<p>{{ issue.description }}</p>{% endif %}`
+     block, keep the `rationale` and `ruleChangeText` blocks as-is.
+   - Ballot page (`templates/proposals/ballot.html.twig`): show only
+     `Description` (the short description) — drop `Rationale` and
+     `RuleChangeText` entirely from the ballot card (ballot currently
+     already omits rationale/rule-change-text, so only confirm this and
+     leave `issue.description` as the sole summary shown per item).
+
+3. **Article cards — comment count indicator.** The article card partial
+   (`templates/article/_card.html.twig`, used by `article/list.html.twig`
+   and `home/index.html.twig`) shows title/date/author only, no hint of
+   discussion activity. `Comment` (`src/Entity/Comment.php`) has a plain
+   `article_id` int column, not a Doctrine relation, and there's no
+   existing count lookup — add one:
+   - add a `countByArticle(int $articleId)` (or a batch
+     `countByArticleIds(array $ids)` to avoid N+1 across a page of cards)
+     to `CommentRepository`, counting only `active` comments;
+   - thread the count(s) through `ArticleController::list` and
+     `HomeController` into the `_card.html.twig` include (card currently
+     receives just `article`; extend the include context, e.g.
+     `{article: a, commentCount: counts[a.id]}`);
+   - show a small comment-count badge/icon on the card (e.g. "💬 12" or a
+     Bootstrap badge), matching existing card styling.
+
+4. **Login form alongside "must be logged in" messages.** A global login
+   modal (`#loginModal`, `templates/base.html.twig:88-117`) already exists
+   on every page and is opened by a navbar "Log In" button
+   (`base.html.twig:83`), but the following gated pages show a plain
+   logged-out message with no way to log in right there — the user has to
+   notice and click the separate navbar button:
+   - `templates/transactions/protections_saved.html.twig:12`
+   - `templates/transactions/protections.html.twig:10`
+   - `templates/transactions/ir.html.twig:16`
+   - `templates/transactions/list.html.twig:12`
+   - `templates/transactions/confirm.html.twig:11`
+   - `templates/draftdate/index.html.twig:10`
+   - `templates/proposals/ballot.html.twig:10`
+   - `templates/proposals/submit.html.twig:17`
+   - `templates/trades/index.html.twig:12`
+   - `templates/article/publish.html.twig:16`
+   Add a "Log In" button next to each message that opens the existing
+   modal (`data-toggle="modal" data-target="#loginModal"`, same as the
+   navbar button) rather than duplicating the form — since the wording and
+   markup are near-identical across all ten, factor them into one shared
+   Twig partial (e.g. `_login_required.html.twig`) taking the message text,
+   and swap each site to include it. Also check
+   `ArticleController::addComment` (`src/Controller/ArticleController.php:83`),
+   which flashes "You must be logged in to comment" — the redirect target
+   still has the navbar modal available, but confirm the flash is rendered
+   somewhere with a visible trigger, or add one.
+
+## Phase 12 — Admin tooling
+
+Two self-contained admin-only tools, split out of Phase 11 since they're
+scoped work in their own right rather than one-line polish.
+
+1. **Quicklinks admin — drag-and-drop ordering.** The admin quicklinks
+   index (`templates/admin/quicklinks/index.html.twig`) lists links with a
+   plain `Order` column; reordering today means opening each link's edit
+   form and hand-editing the `sortOrder` number input
+   (`templates/admin/quicklinks/edit.html.twig`) until the list order
+   changes — tedious and error-prone with more than a couple of links.
+   Replace with drag-and-drop reordering on the index page:
+   - make the table rows draggable (e.g. SortableJS, consistent with any
+     drag-and-drop library already used elsewhere in the admin UI, or a
+     small vanilla HTML5 drag-and-drop handler if none exists);
+   - on drop, POST the new ordering to a new route (e.g.
+     `admin_quicklinks_reorder`) that accepts an ordered list of link IDs
+     and rewrites `sortOrder` sequentially in `AdminQuickLinkController`;
+   - keep the manual `sortOrder` field on the edit form as a fallback (or
+     drop it if drag-and-drop fully replaces it — decide during
+     implementation), but the index page becomes the primary way to
+     reorder.
+
+2. **Admin config editor.** `App\Entity\Config` / `ConfigRepository`
+   (`symfony-app/src/Entity/Config.php`) map the existing `config` table
+   (flat `key` varchar PK / `value` varchar, 54 rows today) but nothing in
+   the Symfony app reads or writes it yet — it's untouched scaffolding.
+   Build a generic admin CRUD tool for it, following the
+   `AdminQuickLinkController` pattern (`src/Controller/Admin/AdminQuickLinkController.php`,
+   `templates/admin/quicklinks/`):
+   - `AdminConfigController` under `/admin/config`: index (table of all
+     key/value pairs, `requireCommissioner` gate like other admin
+     controllers), edit (change a value), new (add a key), delete;
+   - note the table currently mixes true settings (`draft.hangout.url`,
+     `draft.clock.*`, `protections.deadline`, `draft.start`) with
+     per-team/per-user runtime state written by the draft flow
+     (`draft.login.<userid>`, `draft.team.<teamid>`,
+     `draft.order.team.<teamid>`, `draft.order.word.<teamid>`) — the tool
+     itself doesn't need to distinguish these (plain generic editor is
+     fine), but don't build any caching/eager-load assumption that treats
+     the table as small/static, since the draft-state rows churn.
+
+## Phase 13 — Symfony-appropriate error handling
+
+Legacy fallback (`symfony-app/public/index.php`, `LegacyBridge.php`) currently
+makes error behavior inconsistent and, in one common case, actively worse than
+either side alone. `index.php` decides whether to fall back to legacy purely
+by checking `$response->isNotFound()` (status 404) — it can't tell a genuinely
+unrouted URL apart from a deliberate `$this->createNotFoundException(...)`
+thrown by a matched Symfony controller (there are ~20 of these today, e.g.
+`TeamController.php:131,178`, `PlayerProfileController.php:56`,
+`ArticleController.php`, `AdminSeasonController.php`,
+`AdminProposalController.php`). Both land in `LegacyBridge`, which then tries
+to map the URL to a file under `/football/`; when the route is Symfony-only
+(a bad id, not a legacy page), `LegacyBridge::getLegacyScript()` throws
+`"Unhandled legacy mapping for ..."` (`LegacyBridge.php:104`) — an uncaught
+exception raised *after* the Symfony kernel has already finished handling the
+request, so it bypasses Symfony's exception handling, the branded error page,
+and Monolog entirely. Recorded as a known site-wide gotcha since the Articles
+migration; this phase fixes it instead of carrying it to the Final phase.
+
+1. **Stop routing controller-thrown 404s into LegacyBridge.** Only a request
+   where Symfony's router itself found no matching route should ever reach
+   `LegacyBridge` — a 404 thrown from inside a matched controller
+   (`createNotFoundException` on a bad id) should render Symfony's own 404
+   response directly. Distinguish the two in `public/index.php` (e.g. check
+   whether the request carries a matched `_route` attribute) rather than
+   branching on status code alone.
+2. **Custom branded error templates.** Add
+   `templates/bundles/TwigBundle/Exception/error.html.twig` (plus
+   `error404.html.twig`, `error403.html.twig` as needed) so genuine 404s,
+   403s (`createAccessDeniedException` in `TradeController.php`,
+   `RosterMoveController.php`), and 500s get a page matching site styling
+   instead of Symfony's generic default — currently shown as-is since no
+   override exists.
+3. **Close the prod logging gap for 4xx.** `config/packages/monolog.yaml`'s
+   `when@prod` `main` handler floors at `level: error`; Symfony logs most
+   4xx client errors below that, so real 401/403/404s are invisible in
+   `logs/wmffl.log` today. Decide what's worth capturing (e.g. a lower floor
+   or a dedicated 4xx channel) without letting routine bot/crawler noise
+   flood the file.
+4. **Harden the legacy `require` in `LegacyBridge::handleRequest`.** Wrap
+   `require $legacyScriptFilename;` (`LegacyBridge.php:158`) so a fatal error
+   or uncaught exception from legacy code gets logged through Monolog (not
+   just the unrotated `error_log()` channel) and shown the same branded
+   error page as case 2, rather than a raw, unstyled PHP error dump at
+   whatever status code PHP happens to send.
+5. Add tests covering: a bad-id 404 on a real route renders the branded 404
+   directly (no `LegacyBridge` mapping attempt), a truly unrouted legacy URL
+   still falls through and serves correctly, and a forced legacy fatal error
+   is captured by Monolog.
+
+## Phase 14 — Activations UI modernization
 
 Legacy: `football/activate/submitactivations.php`, `processActivations.php`,
 `currentactivations.php`, `activations.php`/`index.php`,
@@ -251,7 +415,7 @@ Legacy: `football/activate/submitactivations.php`, `processActivations.php`,
 starting/reserve, see every team's current lineup for the week).
 Explicitly **not** in scope: `currentscore.php`/`scoreFunctions.php`, the
 live/historical box-score rendering that also lives in this directory —
-that's Phase 13's Boxscores redesign; this phase only touches the
+that's Phase 16's Boxscores redesign; this phase only touches the
 "set your lineup" and "see everyone's current lineup" pages.
 
 1. Read side: port the roster/opponent/injury/lock query
@@ -289,9 +453,9 @@ that's Phase 13's Boxscores redesign; this phase only touches the
 7. `football/activate/` deleted for everything covered here, with 301s
    (`LegacyActivationRedirectController`) from `activations.php`,
    `submitactivations.php`, `processActivations.php`; `currentscore.php`
-   and `scoreFunctions.php` stay on the LegacyBridge until Phase 13.
+   and `scoreFunctions.php` stay on the LegacyBridge until Phase 16.
 
-## Phase 12 — History (per-season)
+## Phase 15 — History (per-season)
 
 Legacy: `football/history/{year}Season.php` (1992–2017, frozen flat
 pages) and `football/history/{year}Season/` (1992–2026, directories —
@@ -308,14 +472,14 @@ snapshots, and the old-season-only one-offs (`awards`, `newsletters`,
 `breakdown`, `championpreview`, `playoffexplain`/`preview`/`scenewk*`,
 `summary*.inc`, `weeklyscores`, `weeksummary`). Boxscores
 (`{year}Season/boxscores.php`, 2005/2006 only) are explicitly **not**
-in scope — that's Phase 13.
+in scope — that's Phase 16.
 
 1. Design a data model for the per-season hub content (champion,
    runner-up, playoff scores) currently hardcoded per file
 2. A single generic Symfony route/template driven by that data,
    replacing the 30+ individual season files and directories
 
-## Phase 13 — Boxscores redesign
+## Phase 16 — Boxscores redesign
 
 Legacy: the live box score page is `football/activate/currentscore.php`
 (+ `scoreFunctions.php`, `base/scoring.php`) — addressed by
@@ -340,7 +504,7 @@ two different experiences.
    final-result only
 2. Live scoreboard (separate route, e.g. `/scoreboard`): the in-progress
    current-week experience — live scoring, time remaining, reserves —
-   ported from `currentscore.php` as its own page. Phase 13 ports it
+   ported from `currentscore.php` as its own page. Phase 16 ports it
    as-is to establish the split; its own redesign (auto-refresh, richer
    game-day experience) is deferred to the Unscheduled section
 3. Week scoreboard on the box score page: the other games from the same
@@ -355,12 +519,12 @@ two different experiences.
    game state: completed `teamid`+`season`+`week` combos map to the
    gameid route, current-week to the live scoreboard; update the three
    deep-linking entry points. The rest of `football/activate/` (lineup
-   submission flow) was carved out separately as Phase 11
+   submission flow) was carved out separately as Phase 14
 6. Phase 7 table renames are done (final `activations`/`players`/
    `injuries` names in place); data coverage varies by era — degrade
    gracefully for seasons missing stat lines
 
-## Phase 14 — Remaining odds and ends
+## Phase 17 — Remaining odds and ends
 
 Legacy: `login/`, `forum/`, `rules/`, `info.php`, `scores.php`
 
@@ -368,7 +532,7 @@ Legacy: `login/`, `forum/`, `rules/`, `info.php`, `scores.php`
 2. Static/low-traffic pages (rules, info, forum)
 3. Scores
 
-## Phase 15 — Scripts: legacy → Symfony console commands
+## Phase 18 — Scripts: legacy → Symfony console commands
 
 Legacy: `/scripts/` — standalone PHP invoked directly (`php scripts/foo.php`,
 presumably via cron), each pulling in `base.php` (raw `mysqli_connect`
@@ -407,7 +571,7 @@ porting something run once and discarded.
 
 ## Unscheduled — Live scoreboard redesign
 
-Phase 13 splits the live scoreboard out of `currentscore.php` onto its own
+Phase 16 splits the live scoreboard out of `currentscore.php` onto its own
 route as a faithful port. Its actual redesign — a richer game-day
 experience (auto-refresh/streaming scores, in-progress stat lines,
 whatever else game day wants) — happens here, decoupled from the

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -245,66 +245,38 @@ should be small enough to land as its own PR.
   `templates/proposals/list.html.twig` now shows `Rationale` instead of
   the short `Description`; `ballot.html.twig` confirmed already
   `Description`-only. New `MarkdownServiceTest` cases +
-  `tests/Template/ProposalTemplateTest.php`; 793 tests green. Items 3
-  (article comment-count badge) and 4 (login-modal buttons) remain open
-  below.
+  `tests/Template/ProposalTemplateTest.php`; 793 tests green.
+- Article comment-count badges + login-modal buttons (Phase 11 items 3-4
+  complete, 2026-07-31, `specs/2026-07-31-comments-login-polish/`, branch
+  `phase11-proposals-formatting`, PR #55): `CommentRepository::countByArticleIds()`
+  batch-counts active comments per article, wired through
+  `ArticleController::list`/`HomeController::index` into a `counts` map that
+  `article/_card.html.twig` reads via Twig's inherited include context —
+  every card always shows a `💬 N` badge, including 0. New shared
+  `templates/_login_required.html.twig` partial (message + a `btn-wmffl`
+  button opening the existing navbar `#loginModal`) swapped into all ten
+  gated "must be logged in" pages (transactions
+  protections/ir/list/confirm, draftdate, proposals ballot/submit, trades,
+  article publish); `ArticleController::addComment`'s logged-out flash
+  confirmed sufficient as-is (renders on a page where the navbar's login
+  button is already visible), no code change there. New
+  `ArticleCardTemplateTest` + `LoginRequiredTemplateTest` (real Twig
+  renders, not mocked) pin the actual badge/button markup; 812 tests
+  green. Phase 11 complete.
 
-## Phase 11 — Small fixes
+## Phase 11 — Small fixes (complete)
 
 A catch-all phase for small, self-contained fixes and polish that don't
-warrant their own feature phase. Batched here so each can land as a small
-PR (or a few together) rather than blocking on a larger effort.
+warrant their own feature phase. Batched here so each could land as a
+small PR (or a few together) rather than blocking on a larger effort. All
+four items complete 2026-07-31 — see the `Done` entries above
+(`specs/2026-07-31-proposals-formatting/`,
+`specs/2026-07-31-comments-login-polish/`).
 
 1. ~~**Proposal Markdown authoring — line breaks and indentation.**~~
-   **Complete 2026-07-31** — see the `Done` entry above
-   (`specs/2026-07-31-proposals-formatting/`).
-
 2. ~~**Proposal vs. ballot field visibility.**~~
-   **Complete 2026-07-31** — see the `Done` entry above
-   (`specs/2026-07-31-proposals-formatting/`).
-
-3. **Article cards — comment count indicator.** The article card partial
-   (`templates/article/_card.html.twig`, used by `article/list.html.twig`
-   and `home/index.html.twig`) shows title/date/author only, no hint of
-   discussion activity. `Comment` (`src/Entity/Comment.php`) has a plain
-   `article_id` int column, not a Doctrine relation, and there's no
-   existing count lookup — add one:
-   - add a `countByArticle(int $articleId)` (or a batch
-     `countByArticleIds(array $ids)` to avoid N+1 across a page of cards)
-     to `CommentRepository`, counting only `active` comments;
-   - thread the count(s) through `ArticleController::list` and
-     `HomeController` into the `_card.html.twig` include (card currently
-     receives just `article`; extend the include context, e.g.
-     `{article: a, commentCount: counts[a.id]}`);
-   - show a small comment-count badge/icon on the card (e.g. "💬 12" or a
-     Bootstrap badge), matching existing card styling.
-
-4. **Login form alongside "must be logged in" messages.** A global login
-   modal (`#loginModal`, `templates/base.html.twig:88-117`) already exists
-   on every page and is opened by a navbar "Log In" button
-   (`base.html.twig:83`), but the following gated pages show a plain
-   logged-out message with no way to log in right there — the user has to
-   notice and click the separate navbar button:
-   - `templates/transactions/protections_saved.html.twig:12`
-   - `templates/transactions/protections.html.twig:10`
-   - `templates/transactions/ir.html.twig:16`
-   - `templates/transactions/list.html.twig:12`
-   - `templates/transactions/confirm.html.twig:11`
-   - `templates/draftdate/index.html.twig:10`
-   - `templates/proposals/ballot.html.twig:10`
-   - `templates/proposals/submit.html.twig:17`
-   - `templates/trades/index.html.twig:12`
-   - `templates/article/publish.html.twig:16`
-   Add a "Log In" button next to each message that opens the existing
-   modal (`data-toggle="modal" data-target="#loginModal"`, same as the
-   navbar button) rather than duplicating the form — since the wording and
-   markup are near-identical across all ten, factor them into one shared
-   Twig partial (e.g. `_login_required.html.twig`) taking the message text,
-   and swap each site to include it. Also check
-   `ArticleController::addComment` (`src/Controller/ArticleController.php:83`),
-   which flashes "You must be logged in to comment" — the redirect target
-   still has the navbar modal available, but confirm the flash is rendered
-   somewhere with a visible trigger, or add one.
+3. ~~**Article cards — comment count indicator.**~~
+4. ~~**Login form alongside "must be logged in" messages.**~~
 
 ## Phase 12 — Admin tooling
 

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -234,6 +234,20 @@ should be small enough to land as its own PR.
   `Version20260727020000`, then apply
   `scripts/database/migration/2026-07-27-issues-backfill.sql` (regenerate
   per-env recommended), then confirm `MAILER_DSN` in prod `.env.local`.
+- Proposals formatting fixes (Phase 11 items 1-2 complete, 2026-07-31,
+  `specs/2026-07-31-proposals-formatting/`, branch
+  `phase11-proposals-formatting`): `MarkdownService` now sets CommonMark's
+  `soft_break => "<br>\n"` and normalizes leading whitespace to `&nbsp;`
+  before rendering, so a member/admin typing directly into the
+  `Rationale`/`RuleChangeText` fields gets line breaks and indentation
+  that match the imported (Phase 10.6) content instead of having single
+  newlines collapsed; submit-form live-preview JS updated to match.
+  `templates/proposals/list.html.twig` now shows `Rationale` instead of
+  the short `Description`; `ballot.html.twig` confirmed already
+  `Description`-only. New `MarkdownServiceTest` cases +
+  `tests/Template/ProposalTemplateTest.php`; 793 tests green. Items 3
+  (article comment-count badge) and 4 (login-modal buttons) remain open
+  below.
 
 ## Phase 11 — Small fixes
 
@@ -241,36 +255,13 @@ A catch-all phase for small, self-contained fixes and polish that don't
 warrant their own feature phase. Batched here so each can land as a small
 PR (or a few together) rather than blocking on a larger effort.
 
-1. **Proposal Markdown authoring — line breaks and indentation.** New
-   proposals typed into the admin/member Markdown fields (`Rationale`,
-   `RuleChangeText`) swallow single newlines and drop leading-space
-   indentation, so they don't match the imported historical proposals
-   (whose stored Markdown carries hard breaks and `&nbsp;` runs). Fix
-   `MarkdownService` so authored text renders the way it's typed:
-   - set the CommonMark renderer option `soft_break => "<br>\n"` so every
-     newline becomes a line break (a lone `\n` is otherwise a soft break
-     the browser collapses to a space);
-   - normalize leading whitespace to `&nbsp;` before rendering (each space
-     → one `&nbsp;`, tab → four) so typed indentation survives — CommonMark
-     decodes `&nbsp;` to U+00A0, which isn't collapsed, and this also
-     sidesteps the 4-leading-space indented-code-block trap.
-   Update the submit-form live-preview JS to match the server rendering,
-   add tests, and confirm the imported 2025.1 content still renders
-   identically. Blast radius is just the two proposal fields —
-   `MarkdownService` renders nothing else.
+1. ~~**Proposal Markdown authoring — line breaks and indentation.**~~
+   **Complete 2026-07-31** — see the `Done` entry above
+   (`specs/2026-07-31-proposals-formatting/`).
 
-2. **Proposal vs. ballot field visibility.** The two views currently show
-   the same fields; they should be split so each shows only what's
-   relevant to its purpose:
-   - Proposals page (`templates/proposals/list.html.twig`): show
-     `Rationale`, not `Description` (the short description) — drop the
-     `{% if issue.description %}<p>{{ issue.description }}</p>{% endif %}`
-     block, keep the `rationale` and `ruleChangeText` blocks as-is.
-   - Ballot page (`templates/proposals/ballot.html.twig`): show only
-     `Description` (the short description) — drop `Rationale` and
-     `RuleChangeText` entirely from the ballot card (ballot currently
-     already omits rationale/rule-change-text, so only confirm this and
-     leave `issue.description` as the sole summary shown per item).
+2. ~~**Proposal vs. ballot field visibility.**~~
+   **Complete 2026-07-31** — see the `Done` entry above
+   (`specs/2026-07-31-proposals-formatting/`).
 
 3. **Article cards — comment count indicator.** The article card partial
    (`templates/article/_card.html.twig`, used by `article/list.html.twig`

--- a/symfony-app/public/robots.txt
+++ b/symfony-app/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Crawl-Delay: 20
+#Begin Attracta SEO Tools Sitemap. Do not remove
+sitemap: http://cdn.attracta.com/sitemap/2307999.xml.gz
+#End Attracta SEO Tools Sitemap. Do not remove

--- a/symfony-app/src/Controller/ArticleController.php
+++ b/symfony-app/src/Controller/ArticleController.php
@@ -51,12 +51,15 @@ class ArticleController extends AbstractController
     public function list(
         Request $request,
         ArticleRepository $articles,
+        CommentRepository $comments,
         AuthenticationService $auth
     ): Response {
         $page = max(0, $request->query->getInt('page'));
+        $pageArticles = $articles->findActivePage(self::PER_PAGE, $page);
 
         return $this->render('article/list.html.twig', [
-            'articles' => $articles->findActivePage(self::PER_PAGE, $page),
+            'articles' => $pageArticles,
+            'counts' => $comments->countByArticleIds(array_map(static fn ($a) => $a->getId(), $pageArticles)),
             'page' => $page,
             'isLoggedIn' => $auth->isLoggedIn(),
         ]);

--- a/symfony-app/src/Controller/HomeController.php
+++ b/symfony-app/src/Controller/HomeController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Repository\ArticleRepository;
+use App\Repository\CommentRepository;
 use App\Repository\QuickLinkRepository;
 use App\Repository\ScoresRepository;
 use App\Repository\StandingsRepository;
@@ -26,6 +27,7 @@ class HomeController extends AbstractController
         SeasonWeekService $seasonWeekService,
         SeasonRuleService $seasonRules,
         ArticleRepository $articleRepository,
+        CommentRepository $commentRepository,
         ScoresRepository $scoresRepository,
         StandingsRepository $standingsRepository,
         StandingsCalculatorService $calculatorService,
@@ -58,8 +60,11 @@ class HomeController extends AbstractController
             'SELECT f FROM App\Entity\Forum f ORDER BY f.createTime DESC'
         )->setMaxResults(6)->getResult();
 
+        $articles = $articleRepository->findActivePage(4);
+
         return $this->render('home/index.html.twig', [
-            'articles' => $articleRepository->findActivePage(4),
+            'articles' => $articles,
+            'counts' => $commentRepository->countByArticleIds(array_map(static fn ($a) => $a->getId(), $articles)),
             'scores' => $scores,
             'teams' => $teamArray,
             'posts' => $posts,

--- a/symfony-app/src/Repository/CommentRepository.php
+++ b/symfony-app/src/Repository/CommentRepository.php
@@ -76,4 +76,31 @@ class CommentRepository
             'SELECT c, u FROM App\Entity\Comment c LEFT JOIN c.author u ORDER BY c.dateCreated DESC'
         )->setMaxResults($limit)->setFirstResult($offset)->getResult();
     }
+
+    /**
+     * Active comment counts for a set of articles, keyed by article id.
+     * Articles with no active comments are absent from the result (caller
+     * treats a missing key as 0).
+     *
+     * @param int[] $articleIds
+     * @return array<int,int>
+     */
+    public function countByArticleIds(array $articleIds): array
+    {
+        if ($articleIds === []) {
+            return [];
+        }
+
+        $rows = $this->em->createQuery(
+            'SELECT c.articleId AS articleId, COUNT(c.id) AS cnt FROM App\Entity\Comment c
+             WHERE c.articleId IN (:ids) AND c.active = 1 GROUP BY c.articleId'
+        )->setParameter('ids', $articleIds)->getResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(int) $row['articleId']] = (int) $row['cnt'];
+        }
+
+        return $counts;
+    }
 }

--- a/symfony-app/src/Service/MarkdownService.php
+++ b/symfony-app/src/Service/MarkdownService.php
@@ -20,6 +20,7 @@ class MarkdownService
         $this->converter = $converter ?? new CommonMarkConverter([
             'html_input' => 'escape',
             'allow_unsafe_links' => false,
+            'renderer' => ['soft_break' => "<br>\n"],
         ]);
     }
 
@@ -29,6 +30,37 @@ class MarkdownService
             return '';
         }
 
-        return $this->converter->convert($markdown)->getContent();
+        return $this->converter->convert($this->preserveIndentation($markdown))->getContent();
+    }
+
+    /**
+     * Members type real spaces/tabs to indent sub-items, but CommonMark
+     * either strips leading whitespace on a soft-wrapped line or, at 4+
+     * spaces, treats it as an indented code block. Replacing the leading
+     * run of spaces/tabs on each line with &nbsp; sidesteps both: it's not
+     * "indentation" to the parser, but still renders as non-breaking
+     * spaces (matching the encoding ProposalPageParser::toMarkdown already
+     * uses for imported content).
+     */
+    private function preserveIndentation(string $markdown): string
+    {
+        $lines = explode("\n", $markdown);
+
+        foreach ($lines as &$line) {
+            $line = preg_replace_callback(
+                '/^[ \t]+/',
+                static function (array $m): string {
+                    $out = '';
+                    foreach (str_split($m[0]) as $ch) {
+                        $out .= $ch === "\t" ? str_repeat('&nbsp;', 4) : '&nbsp;';
+                    }
+
+                    return $out;
+                },
+                $line,
+            );
+        }
+
+        return implode("\n", $lines);
     }
 }

--- a/symfony-app/templates/_login_required.html.twig
+++ b/symfony-app/templates/_login_required.html.twig
@@ -1,0 +1,7 @@
+{# Shared "must be logged in" message + a button opening the navbar's login modal (#loginModal, base.html.twig) #}
+<div class="text-center font-weight-bold h4 my-3">
+    {{ message }}
+    <div class="mt-2">
+        <button type="button" class="btn btn-wmffl" data-toggle="modal" data-target="#loginModal">Log In</button>
+    </div>
+</div>

--- a/symfony-app/templates/article/_card.html.twig
+++ b/symfony-app/templates/article/_card.html.twig
@@ -4,7 +4,9 @@
         <img class="card-img-top article-img" src="/{{ article.link }}"/>
         <div class="card-body">
             <h4 class="card-title">{{ article.title }}</h4>
-            <p class="card-text">{{ article.displayDate|date('M d, Y') }}<br/>{{ article.author ? article.author.name : '' }}</p>
+            <p class="card-text">{{ article.displayDate|date('M d, Y') }}<br/>{{ article.author ? article.author.name : '' }}
+                <span class="badge badge-secondary">💬 {{ counts[article.id] ?? 0 }}</span>
+            </p>
         </div>
     </a>
 </div>

--- a/symfony-app/templates/article/publish.html.twig
+++ b/symfony-app/templates/article/publish.html.twig
@@ -13,7 +13,7 @@
     <h1 class="full">Publish Article</h1>
 
     {% if not isLoggedIn %}
-        <div class="text-center font-weight-bold h4">You must be logged in to use this feature</div>
+        {{ include('_login_required.html.twig', {message: 'You must be logged in to use this feature'}) }}
     {% else %}
         {% for message in app.flashes('error') %}
             <div class="alert alert-danger" role="alert">{{ message }}</div>

--- a/symfony-app/templates/draftdate/index.html.twig
+++ b/symfony-app/templates/draftdate/index.html.twig
@@ -7,7 +7,7 @@
 <hr size="1"/>
 
 {% if not loggedIn %}
-<p class="text-center font-weight-bold">You must be logged in to use this feature</p>
+{{ include('_login_required.html.twig', {message: 'You must be logged in to use this feature'}) }}
 {% elseif dates is empty %}
 <p class="text-center">No draft dates are up for a vote yet — check back once the
 candidate dates for {{ season }} have been posted.</p>

--- a/symfony-app/templates/proposals/ballot.html.twig
+++ b/symfony-app/templates/proposals/ballot.html.twig
@@ -7,7 +7,7 @@
 <div class="container pb-4">
 
     {% if not isLoggedIn %}
-        <p class="mt-3 text-center"><b>You must be logged in to cast your votes.</b></p>
+        {{ include('_login_required.html.twig', {message: 'You must be logged in to cast your votes.'}) }}
     {% elseif items is empty %}
         <p class="mt-3">There are no open issues for you to vote on right now. See the
             <a href="{{ path('proposals_list') }}">proposals list</a>.</p>

--- a/symfony-app/templates/proposals/list.html.twig
+++ b/symfony-app/templates/proposals/list.html.twig
@@ -60,10 +60,6 @@
                     </span>
                 </p>
 
-                {% if issue.description %}
-                    <p>{{ issue.description }}</p>
-                {% endif %}
-
                 {% if issue.rationale %}
                     <div class="proposal-rationale">{{ issue.rationale|markdown_to_html|raw }}</div>
                 {% endif %}

--- a/symfony-app/templates/proposals/submit.html.twig
+++ b/symfony-app/templates/proposals/submit.html.twig
@@ -65,8 +65,18 @@
         function escapeHtml(s) {
             return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         }
+        function preserveIndentation(s) {
+            return s.split('\n').map(function (l) {
+                return l.replace(/^[ \t]+/, function (leading) {
+                    return leading.split('').map(function (ch) {
+                        return ch === '\t' ? '&nbsp;&nbsp;&nbsp;&nbsp;' : '&nbsp;';
+                    }).join('');
+                });
+            }).join('\n');
+        }
         function miniMarkdown(src) {
             var out = escapeHtml(src);
+            out = preserveIndentation(out);
             out = out.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
             out = out.replace(/\*([^*]+)\*/g, '<em>$1</em>');
             out = out.replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g, '<a href="$2">$1</a>');

--- a/symfony-app/templates/proposals/submit.html.twig
+++ b/symfony-app/templates/proposals/submit.html.twig
@@ -14,7 +14,7 @@
     {% endfor %}
 
     {% if not isLoggedIn %}
-        <p class="mt-3">You must be logged in to submit rule proposals.</p>
+        {{ include('_login_required.html.twig', {message: 'You must be logged in to submit rule proposals.'}) }}
     {% else %}
         <p class="mt-3">Propose a rule change year round. Your submission is sent to the
             commissioner for review before it appears on the proposals list and ballot.

--- a/symfony-app/templates/trades/index.html.twig
+++ b/symfony-app/templates/trades/index.html.twig
@@ -9,7 +9,7 @@
 {% include 'transactions/_transmenu.html.twig' %}
 
 {% if not loggedIn %}
-    <div class="text-center font-weight-bold h4">You must be logged in to use this feature</div>
+    {{ include('_login_required.html.twig', {message: 'You must be logged in to use this feature'}) }}
 {% else %}
     <div class="container">
         <p>Any outstanding trade offers will be listed below. If the most recent action

--- a/symfony-app/templates/transactions/confirm.html.twig
+++ b/symfony-app/templates/transactions/confirm.html.twig
@@ -8,7 +8,7 @@
     <hr size="1"/>
 
     {% if not loggedIn %}
-        <div class="text-center font-weight-bold">You must be logged in to perform transactions</div>
+        {{ include('_login_required.html.twig', {message: 'You must be logged in to perform transactions'}) }}
     {% else %}
         <div class="hidden">
             <p>Step 4: Check your available roster room and transaction points. You will not

--- a/symfony-app/templates/transactions/ir.html.twig
+++ b/symfony-app/templates/transactions/ir.html.twig
@@ -13,7 +13,7 @@
 {% include 'transactions/_transmenu.html.twig' %}
 
 {% if eligible is null %}
-    <div class="text-center font-weight-bold h4">You must be logged in to use this feature</div>
+    {{ include('_login_required.html.twig', {message: 'You must be logged in to use this feature'}) }}
 {% else %}
     <div id="irPage" data-update-url="{{ path('transactions_ir_update') }}" data-token="{{ csrf_token(constant('App\\Controller\\InjuredReserveController::CSRF_TOKEN_ID')) }}">
 

--- a/symfony-app/templates/transactions/list.html.twig
+++ b/symfony-app/templates/transactions/list.html.twig
@@ -9,7 +9,7 @@
 {% include 'transactions/_transmenu.html.twig' %}
 
 {% if not loggedIn %}
-    <div class="text-center font-weight-bold h4">You must be logged in to use this feature</div>
+    {{ include('_login_required.html.twig', {message: 'You must be logged in to use this feature'}) }}
 {% else %}
     <div class="container">
         <p>Step 1: Search for players by any of the below criteria and selecting "List Players".

--- a/symfony-app/templates/transactions/protections.html.twig
+++ b/symfony-app/templates/transactions/protections.html.twig
@@ -7,7 +7,7 @@
 <hr size="1"/>
 
 {% if not loggedIn %}
-    <div class="text-center font-weight-bold">You must be logged in to submit protections</div>
+    {{ include('_login_required.html.twig', {message: 'You must be logged in to submit protections'}) }}
 {% else %}
     <div class="container">
         <p>

--- a/symfony-app/templates/transactions/protections_saved.html.twig
+++ b/symfony-app/templates/transactions/protections_saved.html.twig
@@ -8,9 +8,7 @@
 
 <div class="container">
     {% if error == 'not_logged_in' %}
-        <div class="alert alert-secondary" role="alert">
-            You must be logged in to save protections.
-        </div>
+        {{ include('_login_required.html.twig', {message: 'You must be logged in to save protections.'}) }}
     {% elseif error == 'deadline' %}
         <div class="alert alert-secondary" role="alert">
             The deadline for changing protections has passed. Nothing was saved.

--- a/symfony-app/tests/Controller/ArticleControllerTest.php
+++ b/symfony-app/tests/Controller/ArticleControllerTest.php
@@ -140,7 +140,7 @@ class ArticleControllerTest extends TestCase
             ->willReturn([]);
 
         $request = new Request(query: ['page' => '2']);
-        $controller->list($request, $articles, $this->makeAuth(true));
+        $controller->list($request, $articles, $this->makeComments(), $this->makeAuth(true));
 
         $this->assertSame('article/list.html.twig', $controller->renderedView);
         $this->assertSame(2, $controller->renderedParams['page']);
@@ -156,10 +156,28 @@ class ArticleControllerTest extends TestCase
             ->willReturn([]);
 
         $request = new Request(query: ['page' => '-3']);
-        $controller->list($request, $articles, $this->makeAuth(false));
+        $controller->list($request, $articles, $this->makeComments(), $this->makeAuth(false));
 
         $this->assertSame(0, $controller->renderedParams['page']);
         $this->assertFalse($controller->renderedParams['isLoggedIn']);
+    }
+
+    public function testListPassesCommentCountsToTemplate(): void
+    {
+        $controller = $this->makeController();
+        $article1 = $this->makeArticle(1);
+        $article2 = $this->makeArticle(2);
+        $articles = $this->createStub(ArticleRepository::class);
+        $articles->method('findActivePage')->willReturn([$article1, $article2]);
+
+        $comments = $this->createMock(CommentRepository::class);
+        $comments->expects($this->once())->method('countByArticleIds')
+            ->with([1, 2])
+            ->willReturn([1 => 3]);
+
+        $controller->list(new Request(), $articles, $comments, $this->makeAuth(true));
+
+        $this->assertSame([1 => 3], $controller->renderedParams['counts']);
     }
 
     // ---- POST /article/{id}/comment ----
@@ -483,6 +501,7 @@ class ArticleControllerTest extends TestCase
         $comments = $this->createStub(CommentRepository::class);
         $comments->method('find')->willReturn($found);
         $comments->method('findThreadByArticle')->willReturn([]);
+        $comments->method('countByArticleIds')->willReturn([]);
         return $comments;
     }
 

--- a/symfony-app/tests/Controller/HomeControllerTest.php
+++ b/symfony-app/tests/Controller/HomeControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Controller;
 
 use App\Controller\HomeController;
 use App\Repository\ArticleRepository;
+use App\Repository\CommentRepository;
 use App\Repository\QuickLinkRepository;
 use App\Repository\ScoresRepository;
 use App\Repository\StandingsRepository;
@@ -34,7 +35,7 @@ class HomeControllerTest extends TestCase
     public function testIndexUsesCurrentSeasonDuringSeason(): void
     {
         [$controller, $deps] = $this->makeController(week: 5);
-        [, , , $scores, $standings] = $deps;
+        [, , , , $scores, $standings] = $deps;
         $scores->expects($this->once())->method('getLatestWeekScores')->with(2025);
         $standings->expects($this->once())->method('getCurrentStandings')->with(2025, 5);
 
@@ -46,7 +47,7 @@ class HomeControllerTest extends TestCase
     public function testIndexFallsBackToPreviousSeasonInOffSeason(): void
     {
         [$controller, $deps] = $this->makeController(week: 0);
-        [, , , $scores, $standings] = $deps;
+        [, , , , $scores, $standings] = $deps;
         $scores->expects($this->once())->method('getLatestWeekScores')->with(2024);
         $standings->expects($this->once())->method('getCurrentStandings')->with(2024, 16);
 
@@ -63,6 +64,20 @@ class HomeControllerTest extends TestCase
         $articles->expects($this->once())->method('findActivePage')->with(4)->willReturn([]);
 
         $controller->index(...$deps);
+    }
+
+    public function testIndexPassesCommentCountsToTemplate(): void
+    {
+        [$controller, $deps] = $this->makeController(week: 5);
+        [, , $articles, $comments] = $deps;
+        $articles->method('findActivePage')->willReturn([]);
+        $comments->expects($this->once())->method('countByArticleIds')
+            ->with([])
+            ->willReturn([]);
+
+        $controller->index(...$deps);
+
+        $this->assertArrayHasKey('counts', $controller->renderedParams);
     }
 
     // ---- Helpers ----
@@ -91,6 +106,9 @@ class HomeControllerTest extends TestCase
         $articles = $this->createMock(ArticleRepository::class);
         $articles->method('findActivePage')->willReturn([]);
 
+        $comments = $this->createMock(CommentRepository::class);
+        $comments->method('countByArticleIds')->willReturn([]);
+
         $scores = $this->createMock(ScoresRepository::class);
         $scores->method('getLatestWeekScores')->willReturn(null);
 
@@ -111,6 +129,6 @@ class HomeControllerTest extends TestCase
         $em = $this->createStub(EntityManagerInterface::class);
         $em->method('createQuery')->willReturn($query);
 
-        return [$controller, [$seasonWeek, $seasonRules, $articles, $scores, $standings, $calculator, $quickLinks, $em]];
+        return [$controller, [$seasonWeek, $seasonRules, $articles, $comments, $scores, $standings, $calculator, $quickLinks, $em]];
     }
 }

--- a/symfony-app/tests/Repository/CommentRepositoryTest.php
+++ b/symfony-app/tests/Repository/CommentRepositoryTest.php
@@ -126,6 +126,52 @@ class CommentRepositoryTest extends TestCase
         $repo->findPageForAdmin(51, 100);
     }
 
+    // ---- countByArticleIds ----
+
+    public function testCountByArticleIdsMapsRowsByArticleId(): void
+    {
+        $query = $this->createMock(Query::class);
+        $query->expects($this->once())->method('setParameter')
+            ->with('ids', [10, 20])
+            ->willReturnSelf();
+        $query->method('getResult')->willReturn([
+            ['articleId' => '10', 'cnt' => '3'],
+        ]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('createQuery')
+            ->with($this->stringContains('WHERE c.articleId IN (:ids) AND c.active = 1 GROUP BY c.articleId'))
+            ->willReturn($query);
+
+        $repo = new CommentRepository($em);
+
+        $this->assertSame([10 => 3], $repo->countByArticleIds([10, 20]));
+    }
+
+    public function testCountByArticleIdsOmitsArticlesWithNoActiveComments(): void
+    {
+        $query = $this->createMock(Query::class);
+        $query->method('setParameter')->willReturnSelf();
+        $query->method('getResult')->willReturn([]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('createQuery')->willReturn($query);
+
+        $repo = new CommentRepository($em);
+
+        $this->assertSame([], $repo->countByArticleIds([30]));
+    }
+
+    public function testCountByArticleIdsShortCircuitsOnEmptyInput(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('createQuery');
+
+        $repo = new CommentRepository($em);
+
+        $this->assertSame([], $repo->countByArticleIds([]));
+    }
+
     // ---- Helpers ----
 
     private function makeComment(int $id, ?Comment $parent = null): Comment

--- a/symfony-app/tests/Service/MarkdownServiceTest.php
+++ b/symfony-app/tests/Service/MarkdownServiceTest.php
@@ -76,4 +76,43 @@ class MarkdownServiceTest extends TestCase
         // No raw/unescaped HTML leaked through from the source.
         $this->assertStringNotContainsString('&lt;blockquote', $html);
     }
+
+    public function testSingleNewlineRendersAsLineBreak(): void
+    {
+        $html = $this->md->toHtml("First line\nSecond line");
+
+        $this->assertStringContainsString('First line<br', $html);
+        $this->assertStringContainsString('Second line', $html);
+        // Not collapsed into one line with a plain space.
+        $this->assertStringNotContainsString('First line Second line', $html);
+    }
+
+    public function testLeadingSpacesPreserveIndentation(): void
+    {
+        $html = $this->md->toHtml("Top item\n  nested item");
+
+        $this->assertStringNotContainsString('<pre>', $html);
+        $this->assertStringNotContainsString('<code>', $html);
+        // &nbsp; decodes to U+00A0, rendered non-breaking (not collapsed
+        // like an ordinary leading space would be).
+        $this->assertStringContainsString("\u{00A0}\u{00A0}nested item", $html);
+    }
+
+    public function testLeadingTabPreservesIndentation(): void
+    {
+        $html = $this->md->toHtml("Top item\n\tnested item");
+
+        $this->assertStringNotContainsString('<pre>', $html);
+        $this->assertStringContainsString(str_repeat("\u{00A0}", 4) . 'nested item', $html);
+    }
+
+    public function testImportedHardBreakStyleUnaffected(): void
+    {
+        // Trailing double-space before the newline, matching what
+        // ProposalPageParser emits for <br> runs — a Markdown hard break.
+        $html = $this->md->toHtml("line one  \nline two");
+
+        $this->assertStringContainsString('line one<br', $html);
+        $this->assertStringContainsString('line two', $html);
+    }
 }

--- a/symfony-app/tests/Template/ArticleCardTemplateTest.php
+++ b/symfony-app/tests/Template/ArticleCardTemplateTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Tests\Template;
+
+use App\Entity\Article;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+/**
+ * Renders article/_card.html.twig directly to pin the comment-count badge:
+ * always shown (including "0"), reading counts[article.id] from whatever
+ * context the including template passed down.
+ */
+class ArticleCardTemplateTest extends TestCase
+{
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $this->twig = new Environment(new FilesystemLoader(__DIR__ . '/../../templates'));
+
+        $generator = new class implements UrlGeneratorInterface {
+            public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
+            {
+                return "/$name" . ($parameters ? '?' . http_build_query($parameters) : '');
+            }
+
+            public function setContext(RequestContext $context): void
+            {
+            }
+
+            public function getContext(): RequestContext
+            {
+                return new RequestContext();
+            }
+        };
+        $this->twig->addExtension(new RoutingExtension($generator));
+    }
+
+    public function testShowsCommentCountFromParentContext(): void
+    {
+        $article = $this->makeArticle(1);
+
+        $html = $this->twig->render('article/_card.html.twig', [
+            'article' => $article,
+            'counts' => [1 => 3],
+        ]);
+
+        $this->assertStringContainsString('badge', $html);
+        $this->assertStringContainsString('3', $html);
+    }
+
+    public function testShowsZeroBadgeWhenArticleHasNoActiveComments(): void
+    {
+        $article = $this->makeArticle(2);
+
+        $html = $this->twig->render('article/_card.html.twig', [
+            'article' => $article,
+            'counts' => [1 => 3],
+        ]);
+
+        $this->assertStringContainsString('badge', $html);
+        $this->assertMatchesRegularExpression('/badge[^<]*">\s*💬\s*0\s*</', $html);
+    }
+
+    public function testShowsZeroBadgeWhenCountsMissingEntirely(): void
+    {
+        $article = $this->makeArticle(3);
+
+        $html = $this->twig->render('article/_card.html.twig', ['article' => $article]);
+
+        $this->assertMatchesRegularExpression('/badge[^<]*">\s*💬\s*0\s*</', $html);
+    }
+
+    private function makeArticle(int $id): Article
+    {
+        $article = new Article();
+        $ref = new \ReflectionProperty(Article::class, 'id');
+        $ref->setValue($article, $id);
+        $article->setTitle('Test Article');
+        $article->setLink('img/l/abc');
+        $article->setDisplayDate(new \DateTime('2026-07-01 12:00:00'));
+
+        return $article;
+    }
+}

--- a/symfony-app/tests/Template/LoginRequiredTemplateTest.php
+++ b/symfony-app/tests/Template/LoginRequiredTemplateTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Tests\Template;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
+
+/**
+ * Renders the shared _login_required.html.twig partial, then each of the
+ * ten gated pages in their logged-out state, to confirm the "must be
+ * logged in" message is paired with a button opening the navbar's existing
+ * #loginModal (base.html.twig) rather than leaving the visitor to hunt for
+ * the separate navbar button.
+ */
+class LoginRequiredTemplateTest extends TestCase
+{
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $this->twig = new Environment(new FilesystemLoader(__DIR__ . '/../../templates'));
+        $this->twig->addGlobal('auth', new class {
+            public function isLoggedIn(): bool
+            {
+                return false;
+            }
+
+            public function isCommissioner(): bool
+            {
+                return false;
+            }
+        });
+        $this->twig->addGlobal('app', new class {
+            public function flashes(?string $type = null): array
+            {
+                return [];
+            }
+        });
+
+        $generator = new class implements UrlGeneratorInterface {
+            public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
+            {
+                return "/$name" . ($parameters ? '?' . http_build_query($parameters) : '');
+            }
+
+            public function setContext(RequestContext $context): void
+            {
+            }
+
+            public function getContext(): RequestContext
+            {
+                return new RequestContext();
+            }
+        };
+        $this->twig->addExtension(new RoutingExtension($generator));
+        $this->twig->addFunction(new TwigFunction('csrf_token', static fn (string $id): string => "token-$id"));
+    }
+
+    public function testPartialRendersMessageAndLoginButton(): void
+    {
+        $html = $this->twig->render('_login_required.html.twig', ['message' => 'You must be logged in to do the thing.']);
+
+        $this->assertStringContainsString('You must be logged in to do the thing.', $html);
+        $this->assertMatchesRegularExpression('/data-target="#loginModal"[^>]*>Log In</', $html);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: array<string, mixed>, 2: string}>
+     */
+    public static function gatedPageProvider(): array
+    {
+        return [
+            'protections_saved not_logged_in' => [
+                'transactions/protections_saved.html.twig',
+                ['error' => 'not_logged_in'],
+                'You must be logged in to save protections.',
+            ],
+            'protections' => [
+                'transactions/protections.html.twig',
+                ['loggedIn' => false],
+                'You must be logged in to submit protections',
+            ],
+            'ir' => [
+                'transactions/ir.html.twig',
+                ['eligible' => null, 'current' => []],
+                'You must be logged in to use this feature',
+            ],
+            'transactions list' => [
+                'transactions/list.html.twig',
+                ['loggedIn' => false],
+                'You must be logged in to use this feature',
+            ],
+            'transactions confirm' => [
+                'transactions/confirm.html.twig',
+                ['loggedIn' => false],
+                'You must be logged in to perform transactions',
+            ],
+            'draftdate index' => [
+                'draftdate/index.html.twig',
+                ['loggedIn' => false, 'season' => 2026],
+                'You must be logged in to use this feature',
+            ],
+            'proposals ballot' => [
+                'proposals/ballot.html.twig',
+                ['isLoggedIn' => false],
+                'You must be logged in to cast your votes.',
+            ],
+            'proposals submit' => [
+                'proposals/submit.html.twig',
+                ['isLoggedIn' => false],
+                'You must be logged in to submit rule proposals.',
+            ],
+            'trades index' => [
+                'trades/index.html.twig',
+                ['loggedIn' => false],
+                'You must be logged in to use this feature',
+            ],
+            'article publish' => [
+                'article/publish.html.twig',
+                ['isLoggedIn' => false],
+                'You must be logged in to use this feature',
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('gatedPageProvider')]
+    public function testGatedPageShowsLoginButtonAlongsideItsMessage(string $template, array $context, string $expectedMessage): void
+    {
+        $html = $this->twig->render($template, $context);
+
+        $this->assertStringContainsString($expectedMessage, $html);
+        $this->assertMatchesRegularExpression('/data-target="#loginModal"[^>]*>Log In</', $html);
+    }
+}

--- a/symfony-app/tests/Template/ProposalTemplateTest.php
+++ b/symfony-app/tests/Template/ProposalTemplateTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Tests\Template;
+
+use App\Entity\Issue;
+use App\Enum\IssueStatus;
+use App\Service\MarkdownService;
+use App\Twig\MarkdownExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
+
+/**
+ * Renders proposals/list.html.twig and proposals/ballot.html.twig directly
+ * to pin the field-visibility split: the list page shows Rationale (and
+ * RuleChangeText), never the short Description; the ballot page shows only
+ * Description, never Rationale/RuleChangeText.
+ */
+class ProposalTemplateTest extends TestCase
+{
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $this->twig = new Environment(new FilesystemLoader(__DIR__ . '/../../templates'));
+        $this->twig->addExtension(new MarkdownExtension(new MarkdownService()));
+        $this->twig->addGlobal('auth', new class {
+            public function isLoggedIn(): bool
+            {
+                return false;
+            }
+        });
+
+        $generator = new class implements UrlGeneratorInterface {
+            public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
+            {
+                return "/$name" . ($parameters ? '?' . http_build_query($parameters) : '');
+            }
+
+            public function setContext(RequestContext $context): void
+            {
+            }
+
+            public function getContext(): RequestContext
+            {
+                return new RequestContext();
+            }
+        };
+        $this->twig->addExtension(new RoutingExtension($generator));
+        $this->twig->addFunction(new TwigFunction('csrf_token', static fn (string $id): string => "token-$id"));
+    }
+
+    public function testListShowsRationaleNotDescription(): void
+    {
+        $issue = $this->makeIssue(
+            description: 'Short description text',
+            rationale: 'Rationale explaining the change',
+        );
+
+        $html = $this->twig->render('proposals/list.html.twig', [
+            'season' => 2026,
+            'seasons' => [2026],
+            'proposals' => [$issue],
+            'onBallot' => [],
+        ]);
+
+        $this->assertStringContainsString('Rationale explaining the change', $html);
+        $this->assertStringNotContainsString('Short description text', $html);
+    }
+
+    public function testBallotShowsDescriptionNotRationaleOrRuleChange(): void
+    {
+        $issue = $this->makeIssue(
+            description: 'Short description text',
+            rationale: 'Rationale explaining the change',
+            ruleChangeText: 'Change rule IV.A to read something else',
+        );
+
+        $html = $this->twig->render('proposals/ballot.html.twig', [
+            'isLoggedIn' => true,
+            'items' => [[
+                'issue' => $issue,
+                'currentVote' => '',
+                'currentLabel' => '',
+                'labels' => ['accept' => 'Accept', 'reject' => 'Reject', 'abstain' => 'Abstain'],
+            ]],
+        ]);
+
+        $this->assertStringContainsString('Short description text', $html);
+        $this->assertStringNotContainsString('Rationale explaining the change', $html);
+        $this->assertStringNotContainsString('Change rule IV.A to read something else', $html);
+    }
+
+    private function makeIssue(?string $description, ?string $rationale = null, ?string $ruleChangeText = null): Issue
+    {
+        $issue = new Issue();
+        $issue->setIssueNum('26.1');
+        $issue->setIssueName('Test Proposal');
+        $issue->setSeason(2026);
+        $issue->setStatus(IssueStatus::Open);
+        $issue->setDescription($description);
+        $issue->setRationale($rationale);
+        $issue->setRuleChangeText($ruleChangeText);
+
+        return $issue;
+    }
+}


### PR DESCRIPTION
## Summary

All four Phase 11 "small fixes" items from `specs/roadmap.md`:

- **Proposal Markdown authoring** (items 1–2, `specs/2026-07-31-proposals-formatting/`): `MarkdownService` now sets CommonMark's `soft_break => "<br>\n"` and normalizes leading whitespace to `&nbsp;`, so member/admin-typed `Rationale`/`RuleChangeText` renders line breaks and indentation matching imported content; submit-form live-preview JS updated to match. `proposals/list.html.twig` shows `Rationale` instead of the short `Description`; `ballot.html.twig` confirmed already `Description`-only.
- **Article comment-count badges** (item 3, `specs/2026-07-31-comments-login-polish/`): new `CommentRepository::countByArticleIds()`, wired through `ArticleController::list`/`HomeController::index` into a `counts` map; `article/_card.html.twig` always shows a `💬 N` badge (including 0), counting active comments only.
- **Login-modal buttons** (item 4): new shared `_login_required.html.twig` partial, dropped into all ten gated "must be logged in" pages (transactions protections/ir/list/confirm, draftdate, proposals ballot/submit, trades, article publish) — each keeps its own message but now offers a Log In button opening the existing navbar modal instead of leaving the visitor to find it themselves.

812 tests green (up from 781 baseline before this branch).

## Test plan

- [x] `cd symfony-app && vendor/bin/phpunit tests/` — 812/812 passing
- [x] New `MarkdownServiceTest` cases (soft-break/indentation) pass
- [x] New `ProposalTemplateTest`, `CommentRepositoryTest`, `ArticleControllerTest`/`HomeControllerTest`, `ArticleCardTemplateTest`, `LoginRequiredTemplateTest` cases pass
- [x] Manually verified against dev DB: `/articles` and `/` badges match real comment thread counts; all ten gated pages (8 GET + 2 POST) show the Log In button with the right message while logged out
- [x] Confirmed imported 2025.1 proposal content still renders identically after the soft-break change
- [ ] Josh: click through the login-modal buttons in a browser to confirm the modal opens and login flow reloads correctly (I verified the markup/attributes render but couldn't drive an actual browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)