### PR TITLE
Phase 12: admin tooling (quicklinks drag-and-drop + config editor)

### DIFF
--- a/specs/2026-07-31-admin-tooling/plan.md
+++ b/specs/2026-07-31-admin-tooling/plan.md
@@ -1,0 +1,62 @@
+# Phase 12 — Admin tooling: Plan
+
+Branch `phase12-admin-tooling`, one PR. Each task group should land as its
+own commit (or a small number of commits). See `requirements.md` for scope
+and decisions, `validation.md` for the merge bar.
+
+## 1. Quicklinks: reorder route + service logic
+
+1. Confirm whether `templates/base.html.twig` already has a per-page
+   `javascripts`/`stylesheets`-style block for admin templates to hook into
+   (`{% block javascripts %}` or similar); if not, decide where the
+   SortableJS `<script>` tag lives (global in `admin/base.html.twig` vs.
+   scoped to the quicklinks index).
+2. `AdminQuickLinkController::reorder()` — `POST /admin/quicklinks/reorder`,
+   commissioner-gated, CSRF (`admin_quicklink` token), reads the ordered id
+   list from the request, rewrites `sortOrder` sequentially in one flush,
+   ignores unknown ids rather than erroring.
+3. Unit/controller test for `reorder()`: full reorder, partial payload
+   (subset of ids — decide and test the actual behavior chosen), unknown id
+   in payload, CSRF rejection, non-commissioner rejection.
+
+## 2. Quicklinks: drag-and-drop UI
+
+1. Add SortableJS via CDN (`<script src="https://cdn.jsdelivr.net/npm/sortablejs@1/Sortable.min.js">`).
+2. `admin/quicklinks/index.html.twig`: wire `Sortable` on the `<tbody>`,
+   `onEnd` handler posts the new order via `fetch` (CSRF token from a
+   `data-` attribute or hidden field already on the page) to
+   `admin_quicklinks_reorder`.
+3. Remove the `sortOrder` `form-group` from `edit.html.twig`; drop the
+   corresponding read in `AdminQuickLinkController::applyForm()`.
+4. Manual check (see `validation.md`) that drag order persists across a
+   page reload and that `findVisible()`'s homepage ordering follows suit.
+
+## 3. Config editor: controller + routes
+
+1. `AdminConfigController` (`/admin/config`), extending
+   `AbstractAdminController`: `index`, `new` (GET+POST), `edit/{key}`
+   (GET+POST), `delete/{key}` (POST). Confirm the `{key}` route-parameter
+   matching handles dotted keys (`draft.login.14`) correctly — add a
+   `requirements` regex if the default isn't sufficient.
+2. Validation in `new`/`edit`: trim, reject blank key/value, reject
+   duplicate key on `new`.
+3. CSRF (`admin_config` token id) on all three mutating routes.
+
+## 4. Config editor: templates + nav
+
+1. `templates/admin/config/index.html.twig` — full table, key + value,
+   sorted by key, edit/delete actions per row, "Add" button
+   (`btn-wmffl` + `text-center`).
+2. `templates/admin/config/edit.html.twig` (shared by new/edit, matching
+   the quicklinks edit-form pattern) — key input (disabled/hidden on edit,
+   editable on new), value input.
+3. Add "Config" to `templates/admin/base.html.twig`'s sidebar.
+
+## 5. Tests + final pass
+
+1. Controller/unit tests for `AdminConfigController` (CRUD round-trip,
+   duplicate-key rejection, CSRF, commissioner gate) following existing
+   admin-controller test patterns in `tests/`.
+2. Run the full `validation.md` checklist; fix anything it turns up.
+3. Update `specs/roadmap.md`: move Phase 12 into `Done` with a summary
+   entry once validation passes.

--- a/specs/2026-07-31-admin-tooling/requirements.md
+++ b/specs/2026-07-31-admin-tooling/requirements.md
@@ -1,0 +1,156 @@
+# Phase 12 — Admin tooling: Requirements
+
+## Goal
+
+Two small, self-contained admin-only tools, landed together on one branch as
+one PR (branch `phase12-admin-tooling`), per the roadmap's Phase 12 grouping:
+
+- **Part A — Quicklinks drag-and-drop ordering.** Replace the manual
+  `sortOrder` number field on `/admin/quicklinks` with drag-and-drop
+  reordering on the index page.
+- **Part B — Admin config editor.** Build a generic CRUD tool over the
+  `config` table (`App\Entity\Config` / `ConfigRepository` already exist as
+  untouched scaffolding) at `/admin/config`.
+
+## Decisions
+
+1. **One branch, one PR.** Both parts are small and unrelated in domain but
+   grouped by the roadmap as "admin tooling"; same pattern as prior
+   multi-part phases (e.g. Phase 10).
+2. **Drag-and-drop library: SortableJS via CDN.** The app already loads
+   jQuery, Bootstrap, and js-cookie from CDNs in `templates/base.html.twig`
+   (no local vendoring for those three); SortableJS follows the same
+   pattern — one `<script src="https://cdn.jsdelivr.net/npm/sortablejs@.../Sortable.min.js">`
+   tag, no jQuery dependency needed (SortableJS is vanilla JS). Chosen over
+   jQuery UI Sortable (would drag in jQuery UI's CSS/JS for one widget) and
+   over hand-rolled HTML5 drag-and-drop (more code, weaker touch support).
+3. **Drop the manual `sortOrder` field once drag-and-drop lands.** The
+   admin edit form (`templates/admin/quicklinks/edit.html.twig`) removes its
+   `sortOrder` number input; the index page's drag-and-drop becomes the only
+   way to reorder. New links still default to end-of-list (existing
+   behavior in `AdminQuickLinkController::new()`).
+4. **Config editor stays fully generic — no key-prefix special-casing.**
+   The `config` table mixes real settings (`draft.hangout.url`,
+   `protections.deadline`, ...) with per-team/per-user draft-runtime state
+   (`draft.login.<userid>`, `draft.team.<teamid>`, `draft.order.*`) that
+   churns during the draft. The editor does not group, filter, or hide
+   these differently — plain key/value list, add/edit/delete on every row
+   alike. (Matches the roadmap note that a generic editor is fine.) No
+   caching or eager-load assumption that treats the table as small/static.
+5. **Merge bar:** PHPUnit tests (unit + any template/controller tests
+   following existing patterns) plus a manual fake-session E2E checklist
+   (see `validation.md`). No new WebTestCase functional-test infrastructure
+   beyond what the codebase already uses.
+
+## Part A — Quicklinks drag-and-drop ordering
+
+### Current state
+
+- `templates/admin/quicklinks/index.html.twig`: plain `Order` column,
+  numeric, not editable inline.
+- `templates/admin/quicklinks/edit.html.twig`: a `sortOrder` number input
+  (`AdminQuickLinkController::applyForm()` reads it via
+  `$request->request->get('sortOrder', 0)`).
+- `QuickLinkRepository::findAllOrdered()` / `findVisible()` both
+  `ORDER BY sortOrder ASC, id ASC`.
+- No drag-and-drop library anywhere in the codebase today
+  (`jquery.tablesorter` is column-sort, unrelated).
+
+### Scope
+
+1. **New route** `admin_quicklinks_reorder`
+   (`POST /admin/quicklinks/reorder`) on `AdminQuickLinkController`:
+   commissioner-gated, CSRF-protected (same `admin_quicklink` token id as
+   the other mutating actions), accepts an ordered list of quicklink ids
+   (e.g. `ids[]=3&ids[]=1&ids[]=2` or a JSON body — implementer's choice,
+   whichever pairs more naturally with the SortableJS `onEnd` handler),
+   and rewrites `sortOrder` sequentially (1, 2, 3, ...) in that order, in
+   one flush. Ids not present in the payload (shouldn't happen, but don't
+   trust the client) are left alone rather than erroring.
+2. **Index page**: rows become draggable via SortableJS
+   (`new Sortable(tbody, {...})` on the `<tbody>`, handle = the whole row or
+   a small drag-handle cell — implementer's choice). On drop, `onEnd` fires
+   a `fetch` POST to the reorder route with the new id order and the CSRF
+   token (read from a `data-` attribute or hidden input already on the
+   page, matching how other admin pages embed `csrf_token('admin_quicklink')`
+   today); on success, re-render or update the `Order` column values without
+   a full page reload if straightforward, otherwise a simple redirect/reload
+   is acceptable — no client-side framework, just enough vanilla JS to wire
+   SortableJS to the fetch call.
+3. **Edit form**: remove the `sortOrder` input and its `form-group` column
+   from `edit.html.twig`; `AdminQuickLinkController::applyForm()` stops
+   reading/setting `sortOrder` from the request. `new()` keeps its
+   end-of-list default (`end($existing)->getSortOrder() + 1`).
+4. **SortableJS CDN include**: add the `<script>` tag either globally in
+   `templates/admin/base.html.twig` (simplest, consistent with how
+   jQuery/Bootstrap are loaded once for the whole admin section) or scoped
+   to `admin/quicklinks/index.html.twig` via a `{% block javascripts %}`
+   if the base template doesn't already support per-page script blocks —
+   check `templates/base.html.twig` for an existing `javascripts` block
+   before deciding.
+
+## Part B — Admin config editor
+
+### Current state
+
+- `App\Entity\Config` (table `config`): `key` (varchar, PK) / `value`
+  (varchar), no relations. `ConfigRepository` is `ServiceEntityRepository`
+  scaffolding with only commented-out example methods.
+- Nothing in the Symfony app reads or writes this table today. 54 rows in
+  the dev DB currently, e.g. `draft.hangout.url`, `protections.deadline`,
+  `draft.clock.*`, plus ~30 `draft.login.<userid>` / `draft.team.<teamid>` /
+  `draft.order.{team,word}.<teamid>` rows written by the draft flow.
+- Legacy admin tooling for this table (if any existed) is out of scope to
+  investigate — this is new Symfony-only functionality per the mission's
+  "admin tools must exist" principle.
+
+### Scope
+
+1. **`AdminConfigController`** under `/admin/config`, extending
+   `AbstractAdminController` (commissioner gate via `requireCommissioner`,
+   same pattern as `AdminQuickLinkController`):
+   - **Index** (`admin_config`): table of every row, key + value, sorted by
+     key. No pagination needed at 54 rows; don't add a caching layer.
+   - **New** (`admin_config_new`, GET+POST): form for a new key/value pair.
+     Reject (flash error, no persist) if the key already exists (PK
+     collision) or if key/value are blank after trimming.
+   - **Edit** (`admin_config_edit/{key}`, GET+POST): change the `value` for
+     an existing key. The `key` (PK) itself is not editable in place —
+     changing a key is delete-and-recreate, consistent with it being an
+     identity, not a mutable field. Route parameter needs a requirement
+     that safely matches keys containing dots (e.g. `draft.login.14`) —
+     confirm during implementation whether Symfony's default `{key}`
+     matching (which stops at `/`) is sufficient or a `requirements` regex
+     is needed.
+   - **Delete** (`admin_config_delete/{key}`, POST): hard delete, CSRF.
+   - All mutating routes CSRF-protected via `assertCsrfToken`, using a
+     dedicated token id (e.g. `admin_config`), same convention as
+     `admin_quicklink`.
+2. **Templates** under `templates/admin/config/` (`index.html.twig`,
+   `edit.html.twig`), following the quicklinks templates' structure and
+   `btn-wmffl` / `text-center` button conventions.
+3. **Admin nav**: add a "Config" entry to `templates/admin/base.html.twig`'s
+   sidebar list, alongside the existing entries.
+4. **No special handling for `draft.*` runtime rows** (decision #4) — they
+   show and edit exactly like any other row.
+
+## Non-goals
+
+- No redesign of `/admin/quicklinks` beyond the ordering mechanism (window,
+  active-flag, and other fields are unchanged from Phase 10).
+- No validation/typing of config values (e.g. no "this key expects a
+  boolean/timestamp" awareness) — plain strings in, plain strings out.
+- No migration of legacy per-key business logic that happens to read this
+  table today (if any exists in `/football/`) onto a new abstraction — this
+  phase only builds the admin CRUD surface, per the roadmap's scope.
+- No bulk import/export for config rows.
+
+## Context / gotchas carried forward
+
+- Fake-session E2E recipe needs `fullname` in the session (prior-phase
+  gotcha).
+- CSRF pattern: `assertCsrfToken($request, '<id>')` checked after the
+  commissioner gate, on every mutating action — see
+  `AbstractAdminController::assertCsrfToken()`.
+- `btn-wmffl` + `text-center` wrapper is the established convention for all
+  admin buttons (see memory `feedback_button_style`).

--- a/specs/2026-07-31-admin-tooling/validation.md
+++ b/specs/2026-07-31-admin-tooling/validation.md
@@ -1,0 +1,89 @@
+# Phase 12 — Admin tooling: Validation
+
+The phase is done and mergeable when everything below passes. Merge bar
+(decision #5 in `requirements.md`): unit/controller tests (mocked-service
+`TestCase` style, matching e.g. `tests/Controller/AdminDraftDatesControllerTest.php`
+— no new WebTestCase functional-test infrastructure) plus manual
+fake-session E2E.
+
+## Automated
+
+Run from `symfony-app/`: `vendor/bin/phpunit tests/ --coverage-clover coverage.xml`
+
+All pre-existing tests still green, plus new coverage for:
+
+- **`AdminQuickLinkController::reorder()`**
+  - full reordered id list → `sortOrder` rewritten sequentially in the new
+    order
+  - unknown id in the payload → ignored, other rows still reordered
+    correctly, no error
+  - non-commissioner → redirect, no changes persisted
+  - missing/invalid CSRF token → 403, no changes persisted
+- **`AdminQuickLinkController::applyForm()`** no longer reads `sortOrder`
+  from the request (existing sortOrder-related tests, if any, updated to
+  match; new-link end-of-list default still covered)
+- **`AdminConfigController`**
+  - `index` — non-commissioner redirect; commissioner sees all rows
+  - `new` — valid submission persists; blank key/value rejected with flash,
+    nothing persisted; duplicate key rejected with flash, nothing persisted
+  - `edit` — valid submission updates `value`; key itself not mutable
+    through this action; 404 on unknown key
+  - `delete` — removes the row; CSRF enforced; 404 on unknown key
+  - a dotted key (e.g. `draft.login.14`) round-trips correctly through
+    edit/delete routes (confirms the route-parameter matching decision from
+    `plan.md` task 3.1 works)
+
+## Manual E2E (fake-session, `php -S` from `symfony-app/public`)
+
+Use the established fake-session recipe (session must include `fullname`);
+one commissioner session (both tools are commissioner-only) and one
+non-commissioner/logged-out check per tool.
+
+### Part A — quicklinks drag-and-drop
+
+1. `/admin/quicklinks` as commissioner with 3+ links: rows are draggable
+   (visible drag affordance/cursor change).
+2. Drag the last row to the top → order updates on the page; reload the
+   page → new order persists (confirms the `sortOrder` rewrite actually
+   flushed, not just a client-side reorder).
+3. Homepage `/` "Other Links" widget reflects the new order
+   (`findVisible()` follows `sortOrder`).
+4. Edit form (`/admin/quicklinks/{id}/edit`) no longer shows a Sort Order
+   field; saving an edit doesn't reset the row's position.
+5. Add a new link → lands at the end of the current drag-established order,
+   not wherever `sortOrder` arithmetic might otherwise place it.
+6. Non-commissioner/logged-out hitting the reorder POST route directly →
+   redirected like the other admin actions, no change persisted.
+7. Tamper with the CSRF token (or omit it) on the reorder POST → 403, order
+   unchanged.
+
+### Part B — admin config editor
+
+1. `/admin/config` as commissioner: all current rows listed (54 in dev DB
+   as of this spec — count may drift), including both plain settings
+   (`protections.deadline`) and draft-runtime rows (`draft.login.<id>`)
+   shown identically, no grouping/filtering.
+2. Add a new key/value pair → appears in the list.
+3. Attempt to add a key that already exists → rejected with a flash, list
+   unchanged.
+4. Edit an existing value (e.g. bump `protections.deadline`) → change
+   reflected in the list; confirm elsewhere in the app that reads this key
+   (if anything currently does) sees the new value — grep first to check
+   whether anything does.
+5. Delete a row → gone from the list.
+6. Edit/delete a dotted key like `draft.login.14` specifically (not just a
+   simple key) — round-trips without truncating at the dot or erroring on
+   route matching.
+7. Non-commissioner/logged-out on `/admin/config` and its mutating routes →
+   redirected, no changes.
+8. Admin sidebar (`templates/admin/base.html.twig`) shows a "Config" link
+   that highlights active on all `/admin/config*` routes.
+
+## Data / deploy
+
+- No schema migration needed for either part — `quicklinks.sort_order`
+  already exists; `config` table already exists and is unchanged.
+- Deploy note: no special sequencing; both tools are additive UI over
+  existing tables. Verify prod's `config` row count/contents look sane in
+  `/admin/config` post-deploy (first real look at this data through the
+  Symfony app).

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -263,6 +263,31 @@ should be small enough to land as its own PR.
   `ArticleCardTemplateTest` + `LoginRequiredTemplateTest` (real Twig
   renders, not mocked) pin the actual badge/button markup; 812 tests
   green. Phase 11 complete.
+- Admin tooling (Phase 12 complete, 2026-07-31,
+  `specs/2026-07-31-admin-tooling/`, branch `phase12-admin-tooling`):
+  `AdminQuickLinkController::reorder()` (`POST /admin/quicklinks/reorder`)
+  rewrites `sortOrder` sequentially from a client-posted ordered id list;
+  the admin index (`templates/admin/quicklinks/index.html.twig`) gets
+  SortableJS-powered drag-and-drop rows (SortableJS pulled in via CDN,
+  matching the existing jQuery/Bootstrap CDN-include pattern rather than
+  adding a build pipeline); the manual `sortOrder` field is removed from
+  the edit form — the index's drag-and-drop is now the only way to
+  reorder. New `AdminConfigController` (`/admin/config` index/new/edit/
+  delete) gives the previously-untouched `App\Entity\Config`/
+  `ConfigRepository` scaffolding (the `config` table, ~54 rows mixing real
+  settings with per-team/per-user draft-runtime state) a generic key/value
+  CRUD, deliberately with no special-casing between the two kinds of row
+  per the roadmap's original scope; nav entry added to
+  `templates/admin/base.html.twig`. A validation-failure Twig bug was
+  caught and fixed along the way: `admin/config/edit.html.twig` originally
+  read `config.value` unconditionally, which threw on the `new` form's
+  failure-path re-render (`config` is `null` there) and would have
+  silently dropped the user's typed input — fixed by passing plain
+  `key`/`value`/`isEdit` scalars to the template instead of the entity.
+  832 tests green; manually verified end-to-end (drag-reorder persistence
+  + homepage widget ordering, CSRF/non-commissioner rejection, config CRUD
+  round-trip incl. a dotted key) against `php -S -t public public/index.php`
+  with a fake commissioner session. Not yet PR'd.
 
 ## Phase 11 — Small fixes (complete)
 
@@ -278,12 +303,14 @@ four items complete 2026-07-31 — see the `Done` entries above
 3. ~~**Article cards — comment count indicator.**~~
 4. ~~**Login form alongside "must be logged in" messages.**~~
 
-## Phase 12 — Admin tooling
+## Phase 12 — Admin tooling (complete)
 
 Two self-contained admin-only tools, split out of Phase 11 since they're
-scoped work in their own right rather than one-line polish.
+scoped work in their own right rather than one-line polish. Both complete
+2026-07-31 — see the `Done` entry above
+(`specs/2026-07-31-admin-tooling/`).
 
-1. **Quicklinks admin — drag-and-drop ordering.** The admin quicklinks
+1. ~~**Quicklinks admin — drag-and-drop ordering.**~~ The admin quicklinks
    index (`templates/admin/quicklinks/index.html.twig`) lists links with a
    plain `Order` column; reordering today means opening each link's edit
    form and hand-editing the `sortOrder` number input
@@ -301,7 +328,7 @@ scoped work in their own right rather than one-line polish.
      implementation), but the index page becomes the primary way to
      reorder.
 
-2. **Admin config editor.** `App\Entity\Config` / `ConfigRepository`
+2. ~~**Admin config editor.**~~ `App\Entity\Config` / `ConfigRepository`
    (`symfony-app/src/Entity/Config.php`) map the existing `config` table
    (flat `key` varchar PK / `value` varchar, 54 rows today) but nothing in
    the Symfony app reads or writes it yet — it's untouched scaffolding.

--- a/symfony-app/src/Controller/Admin/AdminConfigController.php
+++ b/symfony-app/src/Controller/Admin/AdminConfigController.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Entity\Config;
+use App\Repository\ConfigRepository;
+use App\Service\AuthenticationService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Generic key/value CRUD over the `config` table. The table mixes real
+ * settings (draft.hangout.url, protections.deadline, ...) with per-team/
+ * per-user draft-runtime state (draft.login.<userid>, draft.team.<teamid>,
+ * ...) written by the draft flow; this editor treats every row the same,
+ * deliberately no special-casing.
+ */
+#[Route('/admin/config')]
+class AdminConfigController extends AbstractAdminController
+{
+    #[Route('', name: 'admin_config')]
+    public function index(AuthenticationService $auth, ConfigRepository $configs): Response
+    {
+        if ($redirect = $this->requireCommissioner($auth)) {
+            return $redirect;
+        }
+
+        return $this->render('admin/config/index.html.twig', [
+            'configs' => $configs->findAllOrdered(),
+        ]);
+    }
+
+    #[Route('/new', name: 'admin_config_new', methods: ['GET', 'POST'])]
+    public function new(
+        Request $request,
+        AuthenticationService $auth,
+        ConfigRepository $configs,
+        EntityManagerInterface $em
+    ): Response {
+        if ($redirect = $this->requireCommissioner($auth)) {
+            return $redirect;
+        }
+
+        $key   = '';
+        $value = '';
+
+        if ($request->isMethod('POST')) {
+            $this->assertCsrfToken($request, 'admin_config');
+
+            $key   = trim($request->request->get('key', ''));
+            $value = trim($request->request->get('value', ''));
+
+            if ($key === '' || $value === '') {
+                $this->addFlash('error', 'Key and value are both required');
+            } elseif ($configs->find($key) !== null) {
+                $this->addFlash('error', sprintf('Key "%s" already exists', $key));
+            } else {
+                $config = new Config();
+                $config->setName($key);
+                $config->setValue($value);
+                $em->persist($config);
+                $em->flush();
+                $this->addFlash('success', sprintf('"%s" added', $key));
+
+                return $this->redirectToRoute('admin_config');
+            }
+        }
+
+        return $this->render('admin/config/edit.html.twig', ['isEdit' => false, 'key' => $key, 'value' => $value]);
+    }
+
+    #[Route('/{key}/edit', name: 'admin_config_edit', requirements: ['key' => '[^/]+'], methods: ['GET', 'POST'])]
+    public function edit(
+        string $key,
+        Request $request,
+        AuthenticationService $auth,
+        ConfigRepository $configs,
+        EntityManagerInterface $em
+    ): Response {
+        if ($redirect = $this->requireCommissioner($auth)) {
+            return $redirect;
+        }
+
+        $config = $configs->find($key);
+        if (!$config) {
+            throw $this->createNotFoundException("No config key \"$key\"");
+        }
+
+        $value = $config->getValue();
+
+        if ($request->isMethod('POST')) {
+            $this->assertCsrfToken($request, 'admin_config');
+
+            $value = trim($request->request->get('value', ''));
+            if ($value === '') {
+                $this->addFlash('error', 'Value is required');
+            } else {
+                $config->setValue($value);
+                $em->flush();
+                $this->addFlash('success', sprintf('"%s" updated', $key));
+
+                return $this->redirectToRoute('admin_config');
+            }
+        }
+
+        return $this->render('admin/config/edit.html.twig', ['isEdit' => true, 'key' => $key, 'value' => $value]);
+    }
+
+    #[Route('/{key}/delete', name: 'admin_config_delete', requirements: ['key' => '[^/]+'], methods: ['POST'])]
+    public function delete(
+        string $key,
+        Request $request,
+        AuthenticationService $auth,
+        ConfigRepository $configs,
+        EntityManagerInterface $em
+    ): Response {
+        if ($redirect = $this->requireCommissioner($auth)) {
+            return $redirect;
+        }
+        $this->assertCsrfToken($request, 'admin_config');
+
+        $config = $configs->find($key);
+        if (!$config) {
+            throw $this->createNotFoundException("No config key \"$key\"");
+        }
+
+        $em->remove($config);
+        $em->flush();
+        $this->addFlash('success', sprintf('"%s" deleted', $key));
+
+        return $this->redirectToRoute('admin_config');
+    }
+}

--- a/symfony-app/src/Controller/Admin/AdminQuickLinkController.php
+++ b/symfony-app/src/Controller/Admin/AdminQuickLinkController.php
@@ -91,6 +91,34 @@ class AdminQuickLinkController extends AbstractAdminController
         return $this->render('admin/quicklinks/edit.html.twig', ['link' => $link]);
     }
 
+    #[Route('/reorder', name: 'admin_quicklinks_reorder', methods: ['POST'])]
+    public function reorder(
+        Request $request,
+        AuthenticationService $auth,
+        QuickLinkRepository $quickLinks,
+        EntityManagerInterface $em
+    ): Response {
+        if ($redirect = $this->requireCommissioner($auth)) {
+            return $redirect;
+        }
+        $this->assertCsrfToken($request, 'admin_quicklink');
+
+        $byId = [];
+        foreach ($quickLinks->findAllOrdered() as $link) {
+            $byId[$link->getId()] = $link;
+        }
+
+        $order = 1;
+        foreach ($request->getPayload()->all('ids') as $id) {
+            if (isset($byId[(int) $id])) {
+                $byId[(int) $id]->setSortOrder($order++);
+            }
+        }
+        $em->flush();
+
+        return new Response('', 204);
+    }
+
     #[Route('/{id}/toggle', name: 'admin_quicklinks_toggle', requirements: ['id' => '\d+'], methods: ['POST'])]
     public function toggle(
         int $id,
@@ -175,7 +203,6 @@ class AdminQuickLinkController extends AbstractAdminController
         $link->setStartDate($startDate);
         $link->setEndDate($endDate);
         $link->setActive($request->request->getBoolean('active'));
-        $link->setSortOrder((int) $request->request->get('sortOrder', 0));
 
         return true;
     }

--- a/symfony-app/src/Repository/ConfigRepository.php
+++ b/symfony-app/src/Repository/ConfigRepository.php
@@ -16,28 +16,16 @@ class ConfigRepository extends ServiceEntityRepository
         parent::__construct($registry, Config::class);
     }
 
-    //    /**
-    //     * @return Config[] Returns an array of Config objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('c')
-    //            ->andWhere('c.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('c.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
-
-    //    public function findOneBySomeField($value): ?Config
-    //    {
-    //        return $this->createQueryBuilder('c')
-    //            ->andWhere('c.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+    /**
+     * Every config row, for the admin editor.
+     *
+     * @return Config[]
+     */
+    public function findAllOrdered(): array
+    {
+        return $this->createQueryBuilder('c')
+            ->orderBy('c.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/symfony-app/templates/admin/base.html.twig
+++ b/symfony-app/templates/admin/base.html.twig
@@ -78,6 +78,10 @@
                class="list-group-item list-group-item-action{% if app.request.attributes.get('_route') starts with 'admin_trades' %} active{% endif %}">
                 Trades
             </a>
+            <a href="{{ path('admin_config') }}"
+               class="list-group-item list-group-item-action{% if app.request.attributes.get('_route') starts with 'admin_config' %} active{% endif %}">
+                Config
+            </a>
         </div>
     </div>
     <div class="col-md-10">

--- a/symfony-app/templates/admin/config/edit.html.twig
+++ b/symfony-app/templates/admin/config/edit.html.twig
@@ -1,0 +1,32 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin - {{ isEdit ? 'Edit' : 'Add' }} Config{% endblock %}
+
+{% block admin_content %}
+<h2 class="mt-2">{{ isEdit ? 'Edit Config: ' ~ key : 'Add Config' }}</h2>
+
+<form method="post">
+    <input type="hidden" name="_token" value="{{ csrf_token('admin_config') }}"/>
+    <div class="form-row">
+        <div class="form-group col-md-4">
+            <label for="key">Key</label>
+            {% if isEdit %}
+            <input type="text" class="form-control" id="key" value="{{ key }}" disabled>
+            <small class="form-text text-muted">Keys can't be renamed — delete and re-add instead.</small>
+            {% else %}
+            <input type="text" class="form-control" id="key" name="key" maxlength="255"
+                   value="{{ key }}" required>
+            {% endif %}
+        </div>
+        <div class="form-group col-md-8">
+            <label for="value">Value</label>
+            <input type="text" class="form-control" id="value" name="value" maxlength="255"
+                   value="{{ value }}" required>
+        </div>
+    </div>
+    <div class="text-center my-2">
+        <button type="submit" class="btn btn-wmffl">Save</button>
+        <a class="btn btn-wmffl" href="{{ path('admin_config') }}">Cancel</a>
+    </div>
+</form>
+{% endblock %}

--- a/symfony-app/templates/admin/config/index.html.twig
+++ b/symfony-app/templates/admin/config/index.html.twig
@@ -1,0 +1,45 @@
+{% extends 'admin/base.html.twig' %}
+
+{% block title %}Admin - Config{% endblock %}
+
+{% block admin_content %}
+<h2 class="mt-2">Config</h2>
+
+<p class="text-muted">Raw key/value rows from the <code>config</code> table.
+This includes real settings (e.g. <code>protections.deadline</code>) as well
+as per-team/per-user draft-runtime state written by the draft flow
+(<code>draft.login.*</code>, <code>draft.team.*</code>, ...) — edit with
+care.</p>
+
+<table class="table table-sm table-striped table-bordered">
+    <thead class="thead-dark">
+        <tr>
+            <th>Key</th>
+            <th>Value</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for config in configs %}
+        <tr>
+            <td>{{ config.name }}</td>
+            <td>{{ config.value }}</td>
+            <td class="text-nowrap">
+                <a class="btn btn-sm btn-wmffl" href="{{ path('admin_config_edit', {key: config.name}) }}">Edit</a>
+                <form class="d-inline" method="post" action="{{ path('admin_config_delete', {key: config.name}) }}"
+                      onsubmit="return confirm('Delete &quot;{{ config.name|e('js') }}&quot;?');">
+                    <input type="hidden" name="_token" value="{{ csrf_token('admin_config') }}"/>
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3">No config rows.</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+<div class="text-center my-2">
+    <a class="btn btn-wmffl" href="{{ path('admin_config_new') }}">Add Key</a>
+</div>
+{% endblock %}

--- a/symfony-app/templates/admin/quicklinks/edit.html.twig
+++ b/symfony-app/templates/admin/quicklinks/edit.html.twig
@@ -13,17 +13,14 @@
             <input type="text" class="form-control" id="label" name="label" maxlength="100"
                    value="{{ link.label }}" required>
         </div>
-        <div class="form-group col-md-6">
+        <div class="form-group col-md-8">
             <label for="url">URL</label>
             <input type="text" class="form-control" id="url" name="url" maxlength="255"
                    value="{{ link.url }}" placeholder="/history/teammoney" required>
         </div>
-        <div class="form-group col-md-2">
-            <label for="sortOrder">Sort Order</label>
-            <input type="number" class="form-control" id="sortOrder" name="sortOrder"
-                   value="{{ link.sortOrder }}">
-        </div>
     </div>
+    <p class="text-muted">Order is set by dragging rows on the
+        <a href="{{ path('admin_quicklinks') }}">Quicklinks list</a>.</p>
     <div class="form-row">
         <div class="form-group col-md-4">
             <label for="startDate">Show From</label>

--- a/symfony-app/templates/admin/quicklinks/index.html.twig
+++ b/symfony-app/templates/admin/quicklinks/index.html.twig
@@ -2,17 +2,23 @@
 
 {% block title %}Admin - Quicklinks{% endblock %}
 
+{% block javascripts %}
+    {{ parent() }}
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+{% endblock %}
+
 {% block admin_content %}
 <h2 class="mt-2">Homepage Quicklinks</h2>
 
 <p class="text-muted">Links shown in the "Other Links" box on the homepage.
 A link appears when it is active and today falls inside its date window
-(blank dates are open-ended). Update seasonal URLs each year.</p>
+(blank dates are open-ended). Update seasonal URLs each year. Drag rows by
+the <strong>::</strong> handle to reorder.</p>
 
 <table class="table table-sm table-striped table-bordered">
     <thead class="thead-dark">
         <tr>
-            <th>Order</th>
+            <th></th>
             <th>Label</th>
             <th>URL</th>
             <th>Window</th>
@@ -21,10 +27,11 @@ A link appears when it is active and today falls inside its date window
             <th></th>
         </tr>
     </thead>
-    <tbody>
+    <tbody id="quicklinks-body" data-reorder-url="{{ path('admin_quicklinks_reorder') }}"
+           data-csrf-token="{{ csrf_token('admin_quicklink') }}">
         {% for link in links %}
-        <tr>
-            <td>{{ link.sortOrder }}</td>
+        <tr data-id="{{ link.id }}">
+            <td class="text-muted" style="cursor: grab;">::</td>
             <td>{{ link.label }}</td>
             <td><a href="{{ link.url }}">{{ link.url }}</a></td>
             <td>
@@ -59,4 +66,29 @@ A link appears when it is active and today falls inside its date window
 <div class="text-center my-2">
     <a class="btn btn-wmffl" href="{{ path('admin_quicklinks_new') }}">Add Link</a>
 </div>
+
+<script>
+    (function () {
+        var body = document.getElementById('quicklinks-body');
+        if (!body || typeof Sortable === 'undefined') {
+            return;
+        }
+        Sortable.create(body, {
+            handle: 'td:first-child',
+            animation: 150,
+            onEnd: function () {
+                var ids = Array.prototype.map.call(body.querySelectorAll('tr[data-id]'), function (row) {
+                    return row.dataset.id;
+                });
+                fetch(body.dataset.reorderUrl, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({_token: body.dataset.csrfToken, ids: ids})
+                }).catch(function () {
+                    alert('Could not save the new order — reload and try again.');
+                });
+            }
+        });
+    })();
+</script>
 {% endblock %}

--- a/symfony-app/tests/Controller/AdminConfigControllerTest.php
+++ b/symfony-app/tests/Controller/AdminConfigControllerTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\Admin\AdminConfigController;
+use App\Entity\Config;
+use App\Repository\ConfigRepository;
+use App\Service\AuthenticationService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+#[AllowMockObjectsWithoutExpectations]
+class AdminConfigControllerTest extends TestCase
+{
+    // ---- index ----
+
+    public function testIndexRedirectsWhenNotCommissioner(): void
+    {
+        [$controller, $auth, $configs] = $this->makeController(commissioner: false);
+
+        $response = $controller->index($auth, $configs);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/', $response->getTargetUrl());
+    }
+
+    public function testIndexPassesAllConfigsToTemplate(): void
+    {
+        $rows = [$this->config('a.b', '1'), $this->config('c.d', '2')];
+        [$controller, $auth, $configs] = $this->makeController(commissioner: true, rows: $rows);
+
+        $controller->index($auth, $configs);
+
+        $this->assertSame($rows, $controller->renderedParams['configs']);
+    }
+
+    // ---- new ----
+
+    public function testNewRedirectsWhenNotCommissioner(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: false);
+
+        $response = $controller->new(new Request(), $auth, $configs, $em);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testNewPersistsAndRedirects(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true);
+
+        $em->expects($this->once())->method('persist')->with($this->callback(
+            fn (Config $c) => $c->getName() === 'my.key' && $c->getValue() === 'my value'
+        ));
+        $em->expects($this->once())->method('flush');
+
+        $request  = Request::create('/admin/config/new', 'POST', ['key' => 'my.key', 'value' => 'my value']);
+        $response = $controller->new($request, $auth, $configs, $em);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/admin_config', $response->getTargetUrl());
+    }
+
+    public function testNewRejectsBlankKeyOrValue(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true);
+
+        $em->expects($this->never())->method('persist');
+
+        $request = Request::create('/admin/config/new', 'POST', ['key' => '', 'value' => 'x']);
+        $controller->new($request, $auth, $configs, $em);
+
+        $this->assertCount(1, $controller->flashes);
+        $this->assertSame('error', $controller->flashes[0]['type']);
+    }
+
+    public function testNewRejectsDuplicateKey(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(
+            commissioner: true,
+            rows: [$this->config('dup.key', 'existing')]
+        );
+
+        $em->expects($this->never())->method('persist');
+
+        $request = Request::create('/admin/config/new', 'POST', ['key' => 'dup.key', 'value' => 'x']);
+        $controller->new($request, $auth, $configs, $em);
+
+        $this->assertCount(1, $controller->flashes);
+        $this->assertSame('error', $controller->flashes[0]['type']);
+    }
+
+    public function testNewRejectsInvalidCsrfToken(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true);
+        $controller->csrfValid = false;
+
+        $em->expects($this->never())->method('persist');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->new(Request::create('/admin/config/new', 'POST', ['key' => 'a', 'value' => 'b']), $auth, $configs, $em);
+    }
+
+    // ---- edit ----
+
+    public function testEditThrows404WhenKeyMissing(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true);
+
+        $this->expectException(NotFoundHttpException::class);
+        $controller->edit('missing.key', new Request(), $auth, $configs, $em);
+    }
+
+    public function testEditUpdatesValueAndRedirects(): void
+    {
+        $config = $this->config('draft.login.14', 'old');
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true, rows: [$config]);
+
+        $em->expects($this->once())->method('flush');
+
+        $request  = Request::create('/admin/config/draft.login.14/edit', 'POST', ['value' => 'new']);
+        $response = $controller->edit('draft.login.14', $request, $auth, $configs, $em);
+
+        $this->assertSame('new', $config->getValue());
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/admin_config', $response->getTargetUrl());
+    }
+
+    public function testEditRejectsBlankValue(): void
+    {
+        $config = $this->config('a.b', 'old');
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true, rows: [$config]);
+
+        $em->expects($this->never())->method('flush');
+
+        $request = Request::create('/admin/config/a.b/edit', 'POST', ['value' => '']);
+        $controller->edit('a.b', $request, $auth, $configs, $em);
+
+        $this->assertSame('old', $config->getValue());
+        $this->assertCount(1, $controller->flashes);
+    }
+
+    public function testEditRejectsInvalidCsrfToken(): void
+    {
+        $config = $this->config('a.b', 'old');
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true, rows: [$config]);
+        $controller->csrfValid = false;
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->edit('a.b', Request::create('/admin/config/a.b/edit', 'POST', ['value' => 'new']), $auth, $configs, $em);
+    }
+
+    // ---- delete ----
+
+    public function testDeleteRedirectsWhenNotCommissioner(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: false);
+
+        $response = $controller->delete('a.b', new Request(), $auth, $configs, $em);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+    }
+
+    public function testDeleteThrows404WhenKeyMissing(): void
+    {
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true);
+
+        $this->expectException(NotFoundHttpException::class);
+        $controller->delete('missing.key', new Request(), $auth, $configs, $em);
+    }
+
+    public function testDeleteRemovesConfigAndRedirects(): void
+    {
+        $config = $this->config('a.b', 'x');
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true, rows: [$config]);
+
+        $em->expects($this->once())->method('remove')->with($config);
+        $em->expects($this->once())->method('flush');
+
+        $response = $controller->delete('a.b', new Request(), $auth, $configs, $em);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/admin_config', $response->getTargetUrl());
+    }
+
+    public function testDeleteRejectsInvalidCsrfToken(): void
+    {
+        $config = $this->config('a.b', 'x');
+        [$controller, $auth, $configs, $em] = $this->makeController(commissioner: true, rows: [$config]);
+        $controller->csrfValid = false;
+
+        $em->expects($this->never())->method('remove');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->delete('a.b', new Request(), $auth, $configs, $em);
+    }
+
+    // ---- Helpers ----
+
+    private function config(string $key, string $value): Config
+    {
+        $config = new Config();
+        $config->setName($key);
+        $config->setValue($value);
+
+        return $config;
+    }
+
+    /**
+     * @param Config[] $rows
+     */
+    private function makeController(bool $commissioner, array $rows = []): array
+    {
+        $controller = new class extends AdminConfigController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
+            public ?string $renderedView = null;
+            public ?array $renderedParams = null;
+            public array $flashes = [];
+
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                $this->renderedView   = $view;
+                $this->renderedParams = $parameters;
+
+                return new Response();
+            }
+
+            protected function redirectToRoute(string $route, array $parameters = [], int $status = 302): RedirectResponse
+            {
+                return new RedirectResponse("/$route", $status);
+            }
+
+            public function addFlash(string $type, mixed $message): void
+            {
+                $this->flashes[] = ['type' => $type, 'message' => $message];
+            }
+        };
+
+        $auth = $this->createStub(AuthenticationService::class);
+        $auth->method('isCommissioner')->willReturn($commissioner);
+
+        $byKey = [];
+        foreach ($rows as $row) {
+            $byKey[$row->getName()] = $row;
+        }
+
+        $configs = $this->createStub(ConfigRepository::class);
+        $configs->method('findAllOrdered')->willReturn($rows);
+        $configs->method('find')->willReturnCallback(fn (string $key) => $byKey[$key] ?? null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        return [$controller, $auth, $configs, $em];
+    }
+}

--- a/symfony-app/tests/Controller/AdminQuickLinkControllerTest.php
+++ b/symfony-app/tests/Controller/AdminQuickLinkControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Controller\Admin\AdminQuickLinkController;
+use App\Entity\QuickLink;
+use App\Repository\QuickLinkRepository;
+use App\Service\AuthenticationService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+#[AllowMockObjectsWithoutExpectations]
+class AdminQuickLinkControllerTest extends TestCase
+{
+    public function testReorderRedirectsWhenNotCommissioner(): void
+    {
+        [$controller, $auth, $quickLinks, $em] = $this->makeController(commissioner: false);
+
+        $response = $controller->reorder(new Request(), $auth, $quickLinks, $em);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/', $response->getTargetUrl());
+    }
+
+    public function testReorderRejectsInvalidCsrfToken(): void
+    {
+        [$controller, $auth, $quickLinks, $em] = $this->makeController(commissioner: true, links: [
+            $this->link(1, 1), $this->link(2, 2),
+        ]);
+        $controller->csrfValid = false;
+
+        $em->expects($this->never())->method('flush');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->reorder(new Request(request: ['ids' => ['2', '1']]), $auth, $quickLinks, $em);
+    }
+
+    public function testReorderRewritesSortOrderInGivenOrder(): void
+    {
+        $one   = $this->link(1, 1);
+        $two   = $this->link(2, 2);
+        $three = $this->link(3, 3);
+        [$controller, $auth, $quickLinks, $em] = $this->makeController(commissioner: true, links: [$one, $two, $three]);
+
+        $em->expects($this->once())->method('flush');
+
+        $response = $controller->reorder(
+            new Request(request: ['ids' => ['3', '1', '2']]),
+            $auth,
+            $quickLinks,
+            $em
+        );
+
+        $this->assertSame(1, $three->getSortOrder());
+        $this->assertSame(2, $one->getSortOrder());
+        $this->assertSame(3, $two->getSortOrder());
+        $this->assertSame(204, $response->getStatusCode());
+    }
+
+    public function testReorderIgnoresUnknownIds(): void
+    {
+        $one = $this->link(1, 1);
+        $two = $this->link(2, 2);
+        [$controller, $auth, $quickLinks, $em] = $this->makeController(commissioner: true, links: [$one, $two]);
+
+        $controller->reorder(
+            new Request(request: ['ids' => ['999', '2', '1']]),
+            $auth,
+            $quickLinks,
+            $em
+        );
+
+        $this->assertSame(1, $two->getSortOrder());
+        $this->assertSame(2, $one->getSortOrder());
+    }
+
+    public function testReorderLeavesOmittedLinksUnchanged(): void
+    {
+        $one = $this->link(1, 1);
+        $two = $this->link(2, 5);
+        [$controller, $auth, $quickLinks, $em] = $this->makeController(commissioner: true, links: [$one, $two]);
+
+        $controller->reorder(new Request(request: ['ids' => ['1']]), $auth, $quickLinks, $em);
+
+        $this->assertSame(1, $one->getSortOrder());
+        $this->assertSame(5, $two->getSortOrder());
+    }
+
+    // ---- Helpers ----
+
+    private function link(int $id, int $sortOrder): QuickLink
+    {
+        $link = new QuickLink();
+        $ref  = new \ReflectionProperty(QuickLink::class, 'id');
+        $ref->setAccessible(true);
+        $ref->setValue($link, $id);
+        $link->setSortOrder($sortOrder);
+
+        return $link;
+    }
+
+    /**
+     * @param QuickLink[] $links
+     */
+    private function makeController(bool $commissioner, array $links = []): array
+    {
+        $controller = new class extends AdminQuickLinkController {
+            public bool $csrfValid = true;
+
+            protected function isCsrfTokenValid(string $id, #[\SensitiveParameter] ?string $token): bool
+            {
+                return $this->csrfValid;
+            }
+
+            protected function redirectToRoute(string $route, array $parameters = [], int $status = 302): RedirectResponse
+            {
+                return new RedirectResponse("/$route", $status);
+            }
+
+            protected function render(string $view, array $parameters = [], ?Response $response = null): Response
+            {
+                return new Response();
+            }
+
+            public function addFlash(string $type, mixed $message): void
+            {
+            }
+        };
+
+        $auth = $this->createStub(AuthenticationService::class);
+        $auth->method('isCommissioner')->willReturn($commissioner);
+
+        $quickLinks = $this->createStub(QuickLinkRepository::class);
+        $quickLinks->method('findAllOrdered')->willReturn($links);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        return [$controller, $auth, $quickLinks, $em];
+    }
+}


### PR DESCRIPTION
## Summary
- Quicklinks admin index gets SortableJS-powered drag-and-drop reordering (`POST /admin/quicklinks/reorder`), replacing the manual `sortOrder` number field on the edit form.
- New `AdminConfigController` (`/admin/config`) gives the previously-untouched `Config` entity/table a generic key/value CRUD (index/new/edit/delete), deliberately with no special-casing between real settings and the per-team/per-user draft-runtime rows mixed into the same table.
- Fixed a Twig `RuntimeError` found during manual testing: `admin/config/edit.html.twig` read `config.value` unconditionally, which crashed (and would have silently dropped user input) when re-rendering the `new` form after a validation failure.

Spec: `specs/2026-07-31-admin-tooling/`

## Test plan
- [x] `vendor/bin/phpunit tests/ --coverage-clover coverage.xml` — 832 tests, all green (20 new: 5 quicklinks reorder, 15 config CRUD)
- [x] Manual E2E via `php -S -t public public/index.php` with a fake commissioner session:
  - drag-reorder persists across reload; homepage "Other Links" widget order follows it
  - CSRF rejection and non-commissioner rejection on the reorder route
  - quicklinks edit form no longer shows a Sort Order field
  - config CRUD round-trip including add/edit/delete of a dotted key (`draft.login.14`-style)
  - config duplicate-key and blank-field rejections
  - non-commissioner/logged-out redirected on both tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)