### PR TITLE
Phase 13: Symfony-appropriate error handling

### DIFF
--- a/specs/2026-08-18-error-handling/plan.md
+++ b/specs/2026-08-18-error-handling/plan.md
@@ -1,0 +1,109 @@
+# Phase 13 — Symfony-appropriate error handling: Plan
+
+Branch `phase13-error-handling`, one PR. Each task group should land as its
+own commit (or a small number of commits). See `requirements.md` for scope
+and decisions, `validation.md` for the merge bar.
+
+## 1. Branded error templates
+
+1. Add `templates/bundles/TwigBundle/Exception/error404.html.twig`,
+   `error403.html.twig`, and `error.html.twig` (generic 500/other
+   fallback), each extending `base.html.twig` so nav/footer/CSS stay
+   intact. Minimal content per status: a heading + one line of copy, no
+   illustrations, no dynamic links.
+2. Confirm Symfony's `error_controller`/exception-listener picks these up
+   automatically in `dev` (with `framework.exceptions` or by visiting a
+   route with `?_error` debug tooling) and that they only render in `prod`
+   by default (Symfony shows the debug exception page in `dev`/`APP_DEBUG`
+   regardless — confirm this is still true and desired, no config change
+   needed if so).
+3. Manual check: force each status in isolation (bad-id 404 route,
+   CSRF-403 route, a deliberately-thrown 500) with `APP_ENV=prod` locally
+   and confirm the right template renders.
+
+## 2. `index.php`: route matched-controller errors correctly
+
+1. Change the `if (false === $response->isNotFound())` branch in
+   `public/index.php` to check `$request->attributes->get('_route') !==
+   null` instead — a matched route means Symfony owns the response
+   (whatever its status), only an unmatched route falls back to
+   `LegacyBridge`.
+2. Confirm this doesn't change behavior for the common cases: a normal
+   200 (matched route, unaffected), a truly unrouted legacy URL (no
+   `_route`, still falls back), and the target bug case — a matched route
+   throwing `createNotFoundException` now renders Symfony's branded 404
+   directly instead of attempting a `LegacyBridge` mapping.
+3. Check for any existing test coverage directly exercising `index.php`'s
+   branching; update if present (likely none — this file is typically
+   untested directly, confirm during implementation).
+
+## 3. `LegacyBridge`: branded 404 for unmappable paths
+
+1. In `LegacyBridge::getLegacyScript()`, replace the uncaught `throw new
+   Exception("Unhandled legacy mapping for $requestPathInfo")` with a
+   typed exception the caller can catch and distinguish from other
+   failure modes (e.g. a new `LegacyRouteNotFoundException` or reuse
+   Symfony's `NotFoundHttpException`).
+2. In `LegacyBridge::handleRequest()` (or wherever it's invoked from
+   `index.php`), catch that exception, log it via Monolog (include the
+   original path), and render the same branded 404 template from task
+   group 1 instead of letting the exception escape uncaught.
+3. Confirm the img.php/directory-index/extension-inference logic in
+   `getLegacyScript()` is unaffected — only the final `throw` at the
+   bottom of the function changes.
+
+## 4. `LegacyBridge`: harden the legacy `require`
+
+1. Wrap `require $legacyScriptFilename;` in `try { ... } catch
+   (\Throwable $e) { ... }` — log via Monolog, and if no output has been
+   sent yet, render the branded 500 template; if output has already
+   started (legacy code echoed something before failing), let it be —
+   don't try to un-send a partial response.
+2. Add `register_shutdown_function(...)` alongside the try/catch to catch
+   true fatals (`error_get_last()` with `E_ERROR`/`E_PARSE`/etc. types)
+   that PHP doesn't route through normal exception handling — log via
+   Monolog, emit the branded 500 if headers/output haven't started.
+3. Decide and document (in a code comment) how the shutdown handler
+   avoids double-firing when a normal `\Throwable` was already caught and
+   handled by the try/catch in the same request.
+
+## 5. Monolog: close the prod 4xx logging gap
+
+1. `config/packages/monolog.yaml`: change `when@prod`'s `main` handler
+   `level: error` to `level: warning`.
+2. Confirm `channels: ["!deprecation"]` on that handler is still
+   appropriate (unaffected by the level change, but re-read while
+   touching the file).
+
+## 6. Functional test infra + coverage
+
+1. Confirm `symfony/browser-kit` and `symfony/css-selector` are in
+   `composer.json` (check for `symfony/test-pack`); `composer require
+   --dev` whichever's missing.
+2. Add the first `WebTestCase`-based test file(s) under
+   `tests/Controller/` (naming per convention, e.g.
+   `ErrorHandlingTest.php`), covering:
+   - a bad-id 404 on a real matched route (e.g. hit an existing
+     `createNotFoundException` call site) renders the branded 404
+     directly — no `LegacyBridge` mapping attempt (assert via response
+     content matching the branded template, not the legacy one)
+   - a truly unrouted, legacy-unmappable URL renders the branded 404 via
+     the `LegacyBridge` path from task group 3
+   - a route that still legitimately falls through to legacy (pick a
+     stable, still-legacy page) renders correctly, confirming the
+     `_route`-based branching in task group 2 didn't break the common
+     fallback case
+   - a forced legacy fatal (a small fixture script, or a known
+     already-broken legacy path if one safely exists) is caught, logged,
+     and rendered as the branded 500
+3. Confirm the new tests run cleanly alongside the existing suite (no
+   shared state/session bleed — `WebTestCase` boots a fresh kernel per
+   test by default, but check for interaction with the fake-session
+   pattern other tests may rely on).
+
+## 7. Final pass
+
+1. Run the full `validation.md` checklist (automated + manual E2E); fix
+   anything it turns up.
+2. Update `specs/roadmap.md`: move Phase 13 into `Done` with a summary
+   entry once validation passes.

--- a/specs/2026-08-18-error-handling/plan.md
+++ b/specs/2026-08-18-error-handling/plan.md
@@ -101,6 +101,21 @@ and decisions, `validation.md` for the merge bar.
    test by default, but check for interaction with the fake-session
    pattern other tests may rely on).
 
+**As implemented:** the "matched-route 404" and "unrouted URL" cases landed
+in `tests/Controller/ErrorPagesTest.php` (`WebTestCase`), using two new
+fixture-only routes rather than a real feature route, to avoid depending on
+a provisioned `wmffl_test` database (see `requirements.md`'s "found during
+implementation" note). The "unmappable path" and "legacy script throws"
+cases — which live in `LegacyBridge`, entirely outside the kernel's
+request-handling boundary that `WebTestCase` operates within — landed as
+direct static-method tests in `tests/LegacyBridgeTest.php` instead. The
+real-fatal/shutdown-function case stayed manual-E2E-only, as anticipated;
+its type-filtering logic is unit-tested via the extracted
+`isFatalErrorType()` predicate. Two pieces of test infra needed adding
+that weren't anticipated: `tests/bootstrap.php` (dotenv loading) and
+`APP_RUNTIME_MODE=web=1` in `phpunit.xml` (forces the HTML error renderer
+under PHPUnit's CLI SAPI) — see both files' comments.
+
 ## 7. Final pass
 
 1. Run the full `validation.md` checklist (automated + manual E2E); fix

--- a/specs/2026-08-18-error-handling/requirements.md
+++ b/specs/2026-08-18-error-handling/requirements.md
@@ -1,0 +1,140 @@
+# Phase 13 — Symfony-appropriate error handling: Requirements
+
+## Goal
+
+Fix the LegacyBridge fallback's error behavior, which today is inconsistent
+and, in one common case, actively worse than either side alone (see
+`specs/roadmap.md` Phase 13 for the full problem statement). Branch
+`phase13-error-handling`, one PR.
+
+## Problem recap
+
+- `symfony-app/public/index.php` decides whether to fall back to legacy
+  purely by checking `$response->isNotFound()` — it can't tell a genuinely
+  unrouted URL apart from a deliberate `$this->createNotFoundException(...)`
+  thrown by a matched Symfony controller (~20 call sites today, e.g.
+  `TeamController.php:131,178`, `PlayerProfileController.php:56`,
+  `ArticleController.php`, `AdminConfigController.php`,
+  `AdminProposalController.php`).
+- Both cases land in `LegacyBridge::getLegacyScript()`, which then tries to
+  map the URL to a file under `/football/`. When the route is Symfony-only
+  (a bad id, not a legacy page), it throws `"Unhandled legacy mapping for
+  ..."` (`LegacyBridge.php:104`) — an uncaught exception raised *after* the
+  Symfony kernel already finished handling the request, bypassing Symfony's
+  exception handling, the branded error page, and Monolog entirely.
+- Symfony's own default error pages (for the cases that do render normally)
+  don't match site styling — no override template exists today.
+- `config/packages/monolog.yaml`'s `when@prod` `main` handler floors at
+  `level: error`, so real 401/403/404s are invisible in `logs/wmffl.log`.
+- `LegacyBridge::handleRequest`'s `require $legacyScriptFilename;`
+  (`LegacyBridge.php:158`) is unguarded — a fatal error or uncaught
+  exception from legacy code produces a raw, unstyled PHP error dump, not
+  logged through Monolog.
+
+## Decisions
+
+1. **Distinguish matched-controller vs. unrouted by the `_route` request
+   attribute**, checked in `public/index.php` after `$kernel->handle()`.
+   If `$request->attributes->get('_route')` is set, Symfony's router
+   matched something — any response/exception from that dispatch (404,
+   403, 500) is rendered by Symfony directly, never handed to
+   `LegacyBridge`. Only a request with no matched route (Symfony's own
+   404 with no `_route` attribute) falls back to legacy.
+2. **`LegacyBridge`'s own "can't map this path" case also gets a branded
+   404**, logged via Monolog, instead of the current uncaught `Exception`
+   that bypasses everything. This turns `getLegacyScript()`'s throw into
+   something `LegacyBridge::handleRequest()` (or its caller) catches and
+   converts into the same branded 404 response used elsewhere — the
+   "genuinely unrouted AND unmappable in legacy" dead end becomes a normal
+   404, not a raw uncaught-exception page.
+3. **Branded error templates** at
+   `templates/bundles/TwigBundle/Exception/error404.html.twig`,
+   `error403.html.twig`, and a generic `error.html.twig` fallback (500 and
+   anything else) — extend `base.html.twig` so nav/footer/CSS stay intact,
+   minimal content per status (a heading + one line of copy), no
+   illustrations, no "did you mean" links, no per-code copywriting beyond
+   the essentials. This is the smallest change that meets the roadmap's
+   "matching site styling" goal.
+4. **Lower the prod Monolog `main` handler floor from `error` to
+   `warning`.** Symfony logs 404/403/401 at warning by default, so this is
+   a one-line config change and is enough to close the visibility gap. No
+   noise-filtering/dedicated-channel work in this phase — if bot/crawler
+   404 volume turns out to be a real problem post-deploy, that's a
+   follow-up, not a blocker here.
+5. **Harden the legacy `require`** with `try`/`catch (\Throwable)` around
+   it for catchable errors, **plus `register_shutdown_function`** to catch
+   true fatals (E_ERROR and friends) that PHP doesn't let you catch
+   normally. Both paths: log via Monolog (not just PHP's `error_log()`)
+   and, if headers haven't already been sent, emit the branded 500 page
+   instead of a raw PHP error dump.
+6. **Testing: add WebTestCase functional tests**, the first in this
+   codebase (everything under `tests/Controller/` today mocks `render()`).
+   Justification: Phase 12 found a template-shape bug (`admin/config/
+   edit.html.twig` reading `config.value` unconditionally) invisible to
+   mocked-render unit tests — the whole point of this phase is rendering
+   correctness on the error path, so an actual Twig render in the test
+   suite is required, not just a manual E2E pass. Scope the new
+   `WebTestCase` tests narrowly to error-page rendering (bad-id 404 on a
+   real route, truly unrouted URL, forced legacy fatal) rather than
+   converting existing controller tests.
+7. **Merge bar:** existing unit/controller test suite green, plus the new
+   WebTestCase coverage from decision 6, plus the manual fake-session E2E
+   checklist in `validation.md`.
+
+## Scope
+
+1. `public/index.php`: branch on `$request->attributes->get('_route')`
+   instead of `$response->isNotFound()` to decide Symfony-handles-it vs.
+   LegacyBridge-fallback.
+2. `LegacyBridge::getLegacyScript()` / `handleRequest()`: convert the
+   "can't map this path" case into a branded, logged 404 instead of an
+   uncaught `Exception` that escapes to the caller.
+3. `LegacyBridge::handleRequest()`: wrap the legacy `require` in
+   `try`/`catch (\Throwable)` + `register_shutdown_function`, both paths
+   logging via Monolog and rendering the branded 500 (if nothing has been
+   output yet).
+4. New templates: `templates/bundles/TwigBundle/Exception/error404.html.twig`,
+   `error403.html.twig`, `error.html.twig` (generic/500 fallback).
+5. `config/packages/monolog.yaml`: `when@prod` `main` handler `level:
+   error` → `level: warning`.
+6. New `tests/Controller/ErrorHandling*Test.php` (or similar) using
+   `WebTestCase`, first functional-test infra in the repo — add whatever
+   minimal `phpunit.xml`/bootstrap wiring Symfony's `WebTestCase` needs if
+   it isn't already present.
+7. Existing unit tests updated wherever they assert on the old
+   `isNotFound()`-based branching in `index.php`, if any test currently
+   covers that file directly (check during implementation — `index.php`
+   is typically untested directly, so this may be a no-op).
+
+## Non-goals
+
+- No noise-filtering/dedicated 4xx channel for Monolog — plain floor
+  change only (decision 4).
+- No per-status-code custom copy beyond a minimal heading + one line
+  (decision 3) — no illustrations, no support-contact links, no retry
+  buttons.
+- No conversion of existing mocked-render controller tests to
+  `WebTestCase` — the new functional-test infra is additive, scoped to
+  the error-page paths this phase touches.
+- No change to which controller actions throw 404/403 today (the ~20
+  `createNotFoundException`/`createAccessDeniedException` call sites are
+  unchanged) — this phase only fixes how those exceptions are routed and
+  rendered, not where they're raised.
+- No retry/circuit-breaker logic for legacy fatals — a fatal still means
+  the request fails; the fix is presenting and logging that failure
+  correctly, not making the legacy code more resilient.
+
+## Context / gotchas carried forward
+
+- Fake-session E2E recipe needs `fullname` in the session (prior-phase
+  gotcha).
+- `php -S` manual E2E must be run with `public/index.php` as the router
+  script arg, or dotted URL segments 404 before reaching Symfony (see
+  memory `gotcha_php_s_dotted_paths`).
+- `btn-wmffl` + `text-center` is the established admin button convention —
+  not directly relevant here (no admin UI in this phase) but worth keeping
+  in mind if any error page ends up with a button/link.
+- This is the first phase to introduce `WebTestCase` — check
+  `symfony/browser-kit` and `symfony/css-selector` are present in
+  `composer.json` (`symfony/test-pack` usually bundles these); add if
+  missing.

--- a/specs/2026-08-18-error-handling/requirements.md
+++ b/specs/2026-08-18-error-handling/requirements.md
@@ -138,3 +138,26 @@ and, in one common case, actively worse than either side alone (see
   `symfony/browser-kit` and `symfony/css-selector` are present in
   `composer.json` (`symfony/test-pack` usually bundles these); add if
   missing.
+
+**Found during implementation, not anticipated above:**
+- Kernel-booting tests need `tests/bootstrap.php` to load `.env*` (nothing
+  before this phase booted the kernel, so nothing needed it) — see the
+  comment in `tests/bootstrap.php` and `phpunit.xml`'s `bootstrap` attribute.
+- Kernel-booting tests run under PHP's CLI SAPI, which makes Symfony's
+  `error_renderer` service resolve to `CliErrorRenderer` (plain-text dump)
+  instead of the HTML/Twig one unless `kernel.runtime_mode.web` is forced
+  — `phpunit.xml` sets `APP_RUNTIME_MODE=web=1` for this. Test-suite-only,
+  no effect on real `dev`/`prod` traffic.
+- Every real matched-route 404 in this app reads from the DB before it can
+  404 (`SeasonWeekService` et al.), which would make `ErrorPagesTest.php`
+  depend on a provisioned `wmffl_test` database. Sidestepped with two
+  dedicated fixture routes (`tests/Fixtures/Controller/
+  ErrorFixtureController.php`, wired only `when@test` in
+  `config/routes.yaml`) that throw the target exceptions directly — see
+  `validation.md`'s Automated section.
+- `LegacyBridge`'s own branded-404 (unmappable-path case) always renders
+  the branded template regardless of `kernel.debug`, since it calls
+  `LegacyErrorPageService::renderErrorPage()` directly rather than going
+  through Symfony's `TwigErrorRenderer` — an intentional asymmetry with
+  the Symfony-routed 404/403/500 case (decision 3), not a bug. See
+  `validation.md` manual E2E #7.

--- a/specs/2026-08-18-error-handling/validation.md
+++ b/specs/2026-08-18-error-handling/validation.md
@@ -1,0 +1,75 @@
+# Phase 13 — Symfony-appropriate error handling: Validation
+
+The phase is done and mergeable when everything below passes. Merge bar
+(decision 7 in `requirements.md`): existing unit/controller test suite
+green, plus new `WebTestCase` functional coverage for the error paths, plus
+manual fake-session E2E.
+
+## Automated
+
+Run from `symfony-app/`: `vendor/bin/phpunit tests/ --coverage-clover coverage.xml`
+
+All pre-existing tests still green, plus new coverage for:
+
+- **`public/index.php` routing decision** (via the new `WebTestCase` tests,
+  since this file has no direct unit test) — a matched route's
+  `createNotFoundException` renders Symfony's branded 404 directly, no
+  `LegacyBridge` mapping attempted; an unmatched route still falls through
+  to `LegacyBridge` and serves the legacy page correctly.
+- **`LegacyBridge::getLegacyScript()`** — unmappable path throws the new
+  typed exception (not a bare `Exception`); existing img.php / directory /
+  extension-inference behavior unchanged (regression-check existing tests
+  if any cover this method, or add if none do).
+- **`LegacyBridge::handleRequest()`**
+  - unmappable path → branded 404 rendered, logged via Monolog (assert on
+    a test/mock log handler or captured log output)
+  - legacy script throwing a catchable `\Throwable` → branded 500
+    rendered, logged via Monolog, no raw PHP error output in the response
+    body
+  - legacy fatal (shutdown-function path) → branded 500 rendered, logged
+    via Monolog
+- **New `WebTestCase` suite** (first in the repo) boots cleanly, runs
+  alongside the existing mocked-render `tests/Controller/` suite without
+  interference.
+
+## Manual E2E (fake-session, `php -S` with `public/index.php` as router
+script — see `gotcha_php_s_dotted_paths`)
+
+1. Hit a real Symfony route with a bad id (e.g. `/team/999999`) →
+   branded 404 page, site nav/footer/CSS intact, correct HTTP 404 status
+   (check via browser devtools/`curl -I`). Confirm this happened *without*
+   `LegacyBridge` attempting a mapping (no legacy-side log entry / no
+   `football/team/999999.php` lookup).
+2. Hit a genuinely nonexistent URL with no legacy equivalent (e.g.
+   `/this-page-does-not-exist-anywhere`) → branded 404, not the raw
+   `"Unhandled legacy mapping for ..."` exception dump.
+3. Hit a route that legitimately still falls through to legacy (pick a
+   live, unmigrated `/football/` page) → renders correctly as before,
+   confirming the `_route`-based branching didn't regress the common
+   fallback case.
+4. Trigger a CSRF-403 on an existing protected POST route (e.g. a trade or
+   admin action with a bad/missing token) → branded 403 page, not a
+   generic Symfony debug page or legacy fallback.
+5. With `APP_ENV=prod` locally, force a legacy fatal (temporarily break a
+   known legacy script, or use a scratch fixture) → branded 500 page shown
+   to the user (no raw PHP error dump), and the error appears in
+   `logs/wmffl.log` with a stack trace/message, not just PHP's
+   `error_log()`.
+6. With `APP_ENV=prod` locally, confirm a plain 404 (case 1 or 2) now
+   appears in `logs/wmffl.log` — previously invisible below the `error`
+   floor, should now log at `warning`.
+7. Confirm `APP_ENV=dev`/`APP_DEBUG=1` still shows Symfony's normal debug
+   exception page (stack trace, etc.) rather than the branded error
+   templates — the branded pages are a prod-only concern; don't lose the
+   dev debugging experience.
+
+## Data / deploy
+
+- No schema migration needed — this phase touches only application code,
+  templates, and Monolog config.
+- Deploy note: after deploy, watch `logs/wmffl.log` for a period to gauge
+  the volume increase from the `warning` floor change (decision 4 in
+  `requirements.md` explicitly deferred noise-filtering — if bot/crawler
+  404 volume is a real problem, that's a fast-follow, not a blocker for
+  this merge).
+- No new env vars or config keys beyond the `monolog.yaml` level change.

--- a/specs/2026-08-18-error-handling/validation.md
+++ b/specs/2026-08-18-error-handling/validation.md
@@ -9,31 +9,70 @@ manual fake-session E2E.
 
 Run from `symfony-app/`: `vendor/bin/phpunit tests/ --coverage-clover coverage.xml`
 
-All pre-existing tests still green, plus new coverage for:
+All pre-existing tests still green (848 total as of this phase), plus new
+coverage for:
 
-- **`public/index.php` routing decision** (via the new `WebTestCase` tests,
-  since this file has no direct unit test) — a matched route's
-  `createNotFoundException` renders Symfony's branded 404 directly, no
-  `LegacyBridge` mapping attempted; an unmatched route still falls through
-  to `LegacyBridge` and serves the legacy page correctly.
-- **`LegacyBridge::getLegacyScript()`** — unmappable path throws the new
-  typed exception (not a bare `Exception`); existing img.php / directory /
-  extension-inference behavior unchanged (regression-check existing tests
-  if any cover this method, or add if none do).
-- **`LegacyBridge::handleRequest()`**
-  - unmappable path → branded 404 rendered, logged via Monolog (assert on
-    a test/mock log handler or captured log output)
-  - legacy script throwing a catchable `\Throwable` → branded 500
-    rendered, logged via Monolog, no raw PHP error output in the response
-    body
-  - legacy fatal (shutdown-function path) → branded 500 rendered, logged
-    via Monolog
-- **New `WebTestCase` suite** (first in the repo) boots cleanly, runs
-  alongside the existing mocked-render `tests/Controller/` suite without
-  interference.
+- **`tests/Controller/ErrorPagesTest.php`** (`WebTestCase`, first in the
+  repo) — boots the real kernel and asserts on actually-rendered HTML,
+  covering what mocked-`render()` unit tests structurally can't (Phase 12
+  found exactly this class of bug in a non-error template):
+  - a matched-route `NotFoundHttpException`/`AccessDeniedHttpException`
+    renders the branded `error404`/`error403` template, not Symfony's
+    debug page or a generic one
+  - a genuinely unrouted URL (Symfony's own router 404, before any
+    controller runs) also renders the branded 404
+  - uses two dedicated fixture routes (`tests/Fixtures/Controller/
+    ErrorFixtureController.php`, wired only `when@test` in
+    `config/routes.yaml`) rather than a real feature route, specifically
+    so these tests don't depend on a provisioned `wmffl_test` database —
+    every real matched-route 404 in this app reads from the DB before it
+    can 404
+  - boots with `createClient(['debug' => false])`: Symfony only renders
+    the branded templates when `kernel.debug` is off (see manual E2E #7)
+  - **environment gotcha found and fixed**: kernel-booting tests
+    (`WebTestCase`/`KernelTestCase`) run under PHP's CLI SAPI, and
+    Symfony's `error_renderer` service resolves to `CliErrorRenderer`
+    (a VarDumper-style text dump, not HTML) unless
+    `kernel.runtime_mode.web` is forced true — `phpunit.xml` now sets
+    `APP_RUNTIME_MODE=web=1` for this reason. Also required adding
+    `tests/bootstrap.php` (this repo's first kernel-booting test needed
+    `.env*` loaded, which nothing before it did) — see the comments in
+    both files.
+- **`tests/LegacyBridgeTest.php`** — direct static-method calls (no HTTP
+  layer, since `LegacyBridge` runs entirely outside the kernel's
+  request-handling boundary — `WebTestCase` cannot reach it at all):
+  - `getLegacyScript()` throws `LegacyRouteNotFoundException` (not a bare
+    `Exception`) for an unmappable path; still resolves a real legacy file
+    correctly for a mappable one (regression check)
+  - `handleRequest()` on an unmappable path logs via `LegacyErrorPageService
+    ::logNotFound()` and echoes the branded 404, without touching any of
+    the legacy globals/require path
+  - `handleRequest()` catching a `\Throwable` thrown by the required
+    legacy script logs via `logFatal()` (with the exception attached) and
+    echoes the branded 500
+  - `isFatalErrorType()` (the pure, extracted predicate behind the
+    `register_shutdown_function` fatal-type filter) — true for
+    `E_ERROR`/`E_PARSE`/`E_CORE_ERROR`/`E_COMPILE_ERROR`/`E_USER_ERROR`/
+    `E_RECOVERABLE_ERROR`, false for warnings/notices/deprecations/null.
+    **Deliberately not covered directly**: the shutdown-function's actual
+    firing on a real fatal — PHP only runs registered shutdown functions
+    at real script termination, not observable from within a single
+    PHPUnit process without ending it. Covered by manual E2E #5 instead.
+- **`tests/Service/LegacyErrorPageServiceTest.php`** — template selection
+  by status code (404/403/other→generic), and that `logNotFound`/
+  `logFatal` delegate to the logger at the right level with the exception
+  attached when given one.
 
 ## Manual E2E (fake-session, `php -S` with `public/index.php` as router
 script — see `gotcha_php_s_dotted_paths`)
+
+Not run end-to-end as part of this implementation pass — attempts to drive
+a backgrounded `php -S` under `APP_ENV=prod` in the agent sandbox didn't
+reliably pick up the env vars (background-process env propagation is
+unreliable in that harness specifically; a synchronous, non-backgrounded
+`php -r` reproduction of the same request *did* confirm correct behavior
+for both debug=on and debug=off). Josh should run this checklist for real
+before merging:
 
 1. Hit a real Symfony route with a bad id (e.g. `/team/999999`) →
    branded 404 page, site nav/footer/CSS intact, correct HTTP 404 status
@@ -42,26 +81,35 @@ script — see `gotcha_php_s_dotted_paths`)
    `football/team/999999.php` lookup).
 2. Hit a genuinely nonexistent URL with no legacy equivalent (e.g.
    `/this-page-does-not-exist-anywhere`) → branded 404, not the raw
-   `"Unhandled legacy mapping for ..."` exception dump.
+   `"Unhandled legacy mapping for ..."` exception dump. (Confirmed already
+   during implementation via a direct `php -r` request — see above — but
+   worth re-confirming through a real browser.)
 3. Hit a route that legitimately still falls through to legacy (pick a
    live, unmigrated `/football/` page) → renders correctly as before,
    confirming the `_route`-based branching didn't regress the common
-   fallback case.
+   fallback case. (Also spot-checked during implementation.)
 4. Trigger a CSRF-403 on an existing protected POST route (e.g. a trade or
    admin action with a bad/missing token) → branded 403 page, not a
    generic Symfony debug page or legacy fallback.
-5. With `APP_ENV=prod` locally, force a legacy fatal (temporarily break a
-   known legacy script, or use a scratch fixture) → branded 500 page shown
-   to the user (no raw PHP error dump), and the error appears in
-   `logs/wmffl.log` with a stack trace/message, not just PHP's
-   `error_log()`.
-6. With `APP_ENV=prod` locally, confirm a plain 404 (case 1 or 2) now
-   appears in `logs/wmffl.log` — previously invisible below the `error`
-   floor, should now log at `warning`.
-7. Confirm `APP_ENV=dev`/`APP_DEBUG=1` still shows Symfony's normal debug
-   exception page (stack trace, etc.) rather than the branded error
-   templates — the branded pages are a prod-only concern; don't lose the
-   dev debugging experience.
+5. With `APP_ENV=prod` (or any `APP_DEBUG=0` config), force a legacy fatal
+   (temporarily break a known legacy script, or use a scratch fixture) →
+   branded 500 page shown to the user (no raw PHP error dump), and the
+   error appears in `logs/wmffl.log` with a stack trace/message, not just
+   PHP's `error_log()`.
+6. With `APP_DEBUG=0`, confirm a plain 404 (case 1 or 2) now appears in
+   `logs/wmffl.log` — previously invisible below the `error` floor, should
+   now log at `warning`.
+7. Confirm `APP_DEBUG=1` still shows Symfony's normal debug exception page
+   (stack trace, etc.) for a **Symfony-routed** 404/403/500 — the branded
+   pages there are a debug-off concern by design (`TwigErrorRenderer` only
+   picks a custom template when `kernel.debug` is false). Note this does
+   **not** apply to `LegacyBridge`'s own branded 404 for an unmappable
+   path (case 2): that path calls `LegacyErrorPageService::renderErrorPage()`
+   directly rather than going through Symfony's `TwigErrorRenderer`, so it
+   renders the branded template unconditionally, in every environment —
+   confirmed harmless/reasonable during implementation (there's no legacy
+   mapping detail worth debugging beyond "this genuinely doesn't map to
+   anything"), but worth knowing it's an intentional asymmetry, not a bug.
 
 ## Data / deploy
 
@@ -72,4 +120,6 @@ script — see `gotcha_php_s_dotted_paths`)
   `requirements.md` explicitly deferred noise-filtering — if bot/crawler
   404 volume is a real problem, that's a fast-follow, not a blocker for
   this merge).
-- No new env vars or config keys beyond the `monolog.yaml` level change.
+- No new env vars or config keys in the deployed app itself. The only new
+  env var (`APP_RUNTIME_MODE=web=1`) is test-suite-only, set in
+  `phpunit.xml`, and has no effect on `dev`/`prod` runtime.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -288,6 +288,34 @@ should be small enough to land as its own PR.
   + homepage widget ordering, CSRF/non-commissioner rejection, config CRUD
   round-trip incl. a dotted key) against `php -S -t public public/index.php`
   with a fake commissioner session. Not yet PR'd.
+- Symfony-appropriate error handling (Phase 13 complete, 2026-08-19,
+  `specs/2026-08-18-error-handling/`, branch `phase13-error-handling`):
+  `public/index.php` now falls back to `LegacyBridge` only when
+  `$request->attributes->get('_route')` is unset (a real router miss),
+  not merely on a 404 status — a matched controller's own
+  `createNotFoundException()`/`createAccessDeniedException()` now renders
+  Symfony's own response directly instead of `LegacyBridge` trying (and
+  failing) to map it to a `/football/` file. New branded
+  `error404`/`error403`/`error.html.twig` templates under
+  `templates/bundles/TwigBundle/Exception/`, matching site chrome.
+  `LegacyBridge::getLegacyScript()`'s "can't map this path" case now
+  throws a typed `LegacyRouteNotFoundException`, caught by
+  `handleRequest()` and rendered as the branded 404 (logged) instead of
+  escaping as an uncaught exception; the legacy `require` itself is now
+  wrapped in try/catch plus a `register_shutdown_function` fatal-type
+  guard, both paths logging via the new `LegacyErrorPageService` and
+  rendering the branded 500. Prod Monolog's `main` handler floor dropped
+  from `error` to `warning`, closing the previously-invisible 401/403/404
+  logging gap. First `WebTestCase`-based tests in the repo
+  (`tests/Controller/ErrorPagesTest.php`), needed two new pieces of test
+  infra (`tests/bootstrap.php` for dotenv loading;
+  `APP_RUNTIME_MODE=web=1` in `phpunit.xml`, since kernel-booting tests
+  run under CLI SAPI and Symfony's `error_renderer` otherwise picks the
+  plain-text `CliErrorRenderer` over the HTML one) plus two `when@test`
+  fixture routes to avoid needing a provisioned `wmffl_test` database.
+  848 tests green. Manual E2E checklist in `validation.md` not run
+  end-to-end this pass (see that file); Josh to confirm before merge. Not
+  yet PR'd.
 
 ## Phase 11 — Small fixes (complete)
 
@@ -347,7 +375,7 @@ scoped work in their own right rather than one-line polish. Both complete
      fine), but don't build any caching/eager-load assumption that treats
      the table as small/static, since the draft-state rows churn.
 
-## Phase 13 — Symfony-appropriate error handling
+## Phase 13 — Symfony-appropriate error handling (complete)
 
 Legacy fallback (`symfony-app/public/index.php`, `LegacyBridge.php`) currently
 makes error behavior inconsistent and, in one common case, actively worse than

--- a/symfony-app/config/packages/monolog.yaml
+++ b/symfony-app/config/packages/monolog.yaml
@@ -35,7 +35,7 @@ when@prod:
             main:
                 type: rotating_file
                 path: "%kernel.project_dir%/../logs/wmffl.log"
-                level: error
+                level: warning
                 max_files: 14
                 channels: ["!deprecation"]
             console:

--- a/symfony-app/config/routes.yaml
+++ b/symfony-app/config/routes.yaml
@@ -3,3 +3,13 @@ controllers:
         path: ../src/Controller/
         namespace: App\Controller
     type: attribute
+
+when@test:
+    # Fixture routes for ErrorPagesTest (Phase 13) — a matched controller
+    # throwing 404/403 without needing a real feature or a provisioned
+    # wmffl_test database. See tests/Fixtures/Controller/.
+    test_fixture_controllers:
+        resource:
+            path: ../tests/Fixtures/Controller/
+            namespace: App\Tests\Fixtures\Controller
+        type: attribute

--- a/symfony-app/config/services.yaml
+++ b/symfony-app/config/services.yaml
@@ -31,3 +31,6 @@ services:
 
     App\Service\AuthenticationService:
         public: true
+
+    App\Service\LegacyErrorPageService:
+        public: true

--- a/symfony-app/public/index.php
+++ b/symfony-app/public/index.php
@@ -43,8 +43,15 @@ $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 
-if (false === $response->isNotFound()) {
-    // Symfony successfully handled the route.
+if (null !== $request->attributes->get('_route')) {
+    // Symfony's router matched a controller for this request. Whatever
+    // that controller (or Symfony's own exception handling) produced —
+    // 200, a deliberate 404/403 via createNotFoundException()/
+    // createAccessDeniedException(), or a 500 — is the response, full
+    // stop. Only a request the router couldn't match at all falls back
+    // to legacy; a matched route's own 404 must never be handed to
+    // LegacyBridge, which would otherwise try (and typically fail) to
+    // map it to a file under /football/.
     $response->send();
 } else {
     LegacyBridge::handleRequest($request, $response, $kernel->getContainer(), __DIR__);

--- a/symfony-app/src/Exception/LegacyRouteNotFoundException.php
+++ b/symfony-app/src/Exception/LegacyRouteNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exception;
+
+/**
+ * Thrown by LegacyBridge::getLegacyScript() when a request has no matching
+ * Symfony route AND doesn't map to a real file under /football/ either —
+ * a genuine dead end, distinct from every other failure mode in the legacy
+ * mapping logic. Caught by LegacyBridge::handleRequest(), which renders the
+ * branded 404 page instead of letting this escape as an uncaught exception.
+ */
+class LegacyRouteNotFoundException extends \RuntimeException
+{
+}

--- a/symfony-app/src/LegacyBridge.php
+++ b/symfony-app/src/LegacyBridge.php
@@ -3,7 +3,8 @@
 // src/LegacyBridge.php
 namespace App;
 
-use Exception;
+use App\Exception\LegacyRouteNotFoundException;
+use App\Service\LegacyErrorPageService;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,7 +23,8 @@ class LegacyBridge
      * to verify your logic, hence this is public static.
      * @param Request $request
      * @return string
-     * @throws Exception
+     * @throws LegacyRouteNotFoundException if the path has no Symfony route
+     *         and doesn't map to a real file under /football/ either
      */
     public static function getLegacyScript(Request $request): string
     {
@@ -101,7 +103,7 @@ class LegacyBridge
             chdir(dirname($path));
             return $path;
         } else {
-            throw new Exception("Unhandled legacy mapping for $requestPathInfo");
+            throw new LegacyRouteNotFoundException("Unhandled legacy mapping for $requestPathInfo");
         }
 
 
@@ -116,16 +118,25 @@ class LegacyBridge
 //        }
 
         // ... etc.
-
-//        throw new \Exception("Unhandled legacy mapping for $requestPathInfo");
     }
 
-    /**
-     * @throws Exception
-     */
     public static function handleRequest(Request $request, Response $response, ContainerInterface $container, string $publicDirectory): void
     {
-        $legacyScriptFilename = LegacyBridge::getLegacyScript($request);
+        $errorPages = $container->get(LegacyErrorPageService::class);
+
+        try {
+            $legacyScriptFilename = LegacyBridge::getLegacyScript($request);
+        } catch (LegacyRouteNotFoundException $e) {
+            // Symfony's router had no route, and this path doesn't map to a
+            // real file under /football/ either — a genuine dead end. Log
+            // it and render the branded 404 instead of letting the
+            // exception escape uncaught (it would, since the Symfony
+            // kernel has already finished handling this request by the
+            // time we get here).
+            $errorPages->logNotFound($e->getMessage());
+            self::respond($errorPages, 404);
+            return;
+        }
 
         // Make the Symfony entity manager available to the legacy script's scope.
         // This variable will be accessible by the required file below.
@@ -155,6 +166,85 @@ class LegacyBridge
         $_SERVER['SCRIPT_NAME'] = $p;
         $_SERVER['SCRIPT_FILENAME'] = $legacyScriptFilename;
 
-        require $legacyScriptFilename;
+        // Guard against a legacy fatal (or uncaught exception) producing a
+        // raw, unstyled PHP error dump instead of a logged, branded 500.
+        // Two layers, because PHP doesn't route every kind of failure
+        // through normal exception handling:
+        //  - try/catch below covers Throwables — modern PHP turns most
+        //    fatal-class errors (TypeError, ParseError in an included
+        //    file, etc.) into catchable Error objects.
+        //  - the shutdown function covers what's left: true fatals
+        //    (out-of-memory, execution timeout) that PHP never throws as
+        //    an object at all.
+        // $errorHandled prevents the shutdown function from double-firing
+        // when the catch block below already logged and rendered — it
+        // still runs at request end either way, so it has to check first.
+        $errorHandled = false;
+
+        register_shutdown_function(static function () use ($errorPages, $legacyScriptFilename, &$errorHandled): void {
+            if ($errorHandled) {
+                return;
+            }
+
+            $error = error_get_last();
+            if (!self::isFatalErrorType($error)) {
+                // Not a fatal (could be a stray warning/notice from a
+                // successful request) — nothing to do.
+                return;
+            }
+
+            $errorPages->logFatal(sprintf(
+                'Legacy fatal error in %s: %s in %s on line %d',
+                $legacyScriptFilename,
+                $error['message'],
+                $error['file'],
+                $error['line'],
+            ));
+            self::respond($errorPages, 500);
+        });
+
+        try {
+            require $legacyScriptFilename;
+        } catch (\Throwable $e) {
+            $errorHandled = true;
+            $errorPages->logFatal(sprintf('Uncaught %s in legacy script %s', get_class($e), $legacyScriptFilename), $e);
+            self::respond($errorPages, 500);
+        }
+    }
+
+    /**
+     * Whether an error_get_last()-shaped array represents one of PHP's
+     * true fatal error types — the ones that never surface as a catchable
+     * \Throwable and so can only be observed here, in a shutdown function.
+     * A plain static method, not inlined in the shutdown closure, so this
+     * decision is unit-testable without needing to trigger a real fatal.
+     *
+     * @param array{type: int, message: string, file: string, line: int}|null $error
+     */
+    public static function isFatalErrorType(?array $error): bool
+    {
+        if ($error === null) {
+            return false;
+        }
+
+        $fatalTypes = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR];
+        return in_array($error['type'], $fatalTypes, true);
+    }
+
+    /**
+     * Emit the branded error page for the given status, unless the legacy
+     * script already sent output (headers or otherwise) before failing —
+     * in that case there's a partial response on the wire already and
+     * layering another full HTML page on top of it would just corrupt it,
+     * so we settle for having logged the failure.
+     */
+    private static function respond(LegacyErrorPageService $errorPages, int $statusCode): void
+    {
+        if (headers_sent()) {
+            return;
+        }
+
+        http_response_code($statusCode);
+        echo $errorPages->renderErrorPage($statusCode);
     }
 }

--- a/symfony-app/src/Service/LegacyErrorPageService.php
+++ b/symfony-app/src/Service/LegacyErrorPageService.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Service;
+
+use Psr\Log\LoggerInterface;
+use Twig\Environment;
+
+/**
+ * Renders the branded error templates and logs the underlying failure, for
+ * use from LegacyBridge — which runs outside Symfony's normal
+ * controller/exception-handling flow (the kernel has already finished
+ * handling the request by the time LegacyBridge runs), so it can't rely on
+ * Symfony's ErrorController or exception listener to do this automatically.
+ * See specs/2026-08-18-error-handling/ (Phase 13).
+ */
+class LegacyErrorPageService
+{
+    public function __construct(
+        private readonly Environment $twig,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function renderErrorPage(int $statusCode): string
+    {
+        $template = match ($statusCode) {
+            404 => 'bundles/TwigBundle/Exception/error404.html.twig',
+            403 => 'bundles/TwigBundle/Exception/error403.html.twig',
+            default => 'bundles/TwigBundle/Exception/error.html.twig',
+        };
+
+        return $this->twig->render($template);
+    }
+
+    /**
+     * A legacy path that couldn't be routed or mapped to a file at all —
+     * expected traffic (bad links, bots), logged at warning so it doesn't
+     * compete with real errors.
+     */
+    public function logNotFound(string $message): void
+    {
+        $this->logger->warning($message);
+    }
+
+    /**
+     * A legacy script that crashed — a real failure, logged at error with
+     * the original exception (if any) attached for a stack trace.
+     */
+    public function logFatal(string $message, ?\Throwable $exception = null): void
+    {
+        $this->logger->error($message, $exception !== null ? ['exception' => $exception] : []);
+    }
+}

--- a/symfony-app/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/symfony-app/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Something went wrong{% endblock %}
+
+{% block content %}
+<div class="text-center py-5">
+    <h1>Something went wrong</h1>
+    <p>Sorry, an unexpected error occurred. <a href="{{ path('home') }}">Return to the homepage</a>.</p>
+</div>
+{% endblock %}

--- a/symfony-app/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/symfony-app/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Access denied{% endblock %}
+
+{% block content %}
+<div class="text-center py-5">
+    <h1>Access denied</h1>
+    <p>You don't have permission to view this page. <a href="{{ path('home') }}">Return to the homepage</a>.</p>
+</div>
+{% endblock %}

--- a/symfony-app/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/symfony-app/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Page not found{% endblock %}
+
+{% block content %}
+<div class="text-center py-5">
+    <h1>Page not found</h1>
+    <p>The page you're looking for doesn't exist. <a href="{{ path('home') }}">Return to the homepage</a>.</p>
+</div>
+{% endblock %}

--- a/symfony-app/tests/Controller/ErrorPagesTest.php
+++ b/symfony-app/tests/Controller/ErrorPagesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * First WebTestCase-based tests in this codebase (Phase 13,
+ * specs/2026-08-18-error-handling/) — everything else under tests/Controller/
+ * mocks render() rather than actually booting the kernel and rendering Twig.
+ * That's the right default (fast, isolated), but it can't catch a bug in the
+ * error templates themselves (Phase 12 found exactly that kind of bug in a
+ * non-error template) — these tests exist specifically to render the new
+ * branded error templates for real and assert on the HTML they produce.
+ *
+ * Deliberately out of scope here: LegacyBridge's own branded-404/500
+ * rendering (LegacyBridgeTest.php) and the front controller's routing
+ * decision (public/index.php) — both live outside the Symfony kernel's
+ * request-handling boundary that WebTestCase's client operates within, so
+ * they can't be exercised this way. Covered by the manual E2E checklist in
+ * validation.md instead.
+ */
+class ErrorPagesTest extends WebTestCase
+{
+    public function testControllerThrown404RendersBrandedTemplate(): void
+    {
+        $client = $this->debugOffClient();
+        $client->request('GET', '/_test/throws-404');
+
+        $this->assertResponseStatusCodeSame(404);
+        // Scoped to <main>, not a bare "h1" — base.html.twig's login modal
+        // has its own <h1>Log In</h1> earlier in the DOM.
+        $this->assertSelectorTextContains('main h1', 'Page not found');
+    }
+
+    public function testControllerThrown403RendersBrandedTemplate(): void
+    {
+        $client = $this->debugOffClient();
+        $client->request('GET', '/_test/throws-403');
+
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertSelectorTextContains('main h1', 'Access denied');
+    }
+
+    public function testUnroutedUrlRendersBrandedTemplate(): void
+    {
+        $client = $this->debugOffClient();
+        $client->request('GET', '/this-route-truly-does-not-exist-anywhere');
+
+        $this->assertResponseStatusCodeSame(404);
+        $this->assertSelectorTextContains('main h1', 'Page not found');
+    }
+
+    /**
+     * Symfony only renders the branded templates when kernel.debug is off —
+     * otherwise it shows its own debug exception page (by design; see
+     * validation.md's dev/APP_DEBUG check). Boot with debug off so these
+     * tests actually exercise the templates.
+     */
+    private function debugOffClient(): \Symfony\Bundle\FrameworkBundle\KernelBrowser
+    {
+        return static::createClient(['debug' => false]);
+    }
+}

--- a/symfony-app/tests/Fixtures/Controller/ErrorFixtureController.php
+++ b/symfony-app/tests/Fixtures/Controller/ErrorFixtureController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Fixtures\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Test-only routes that throw the exceptions ErrorPagesTest needs to
+ * trigger, without depending on any real feature or the database — every
+ * real matched-route 404 in this app (TeamController, PlayerProfileController,
+ * ...) reads from the DB before it can 404, which would make these tests
+ * depend on a provisioned wmffl_test database. Registered only for
+ * APP_ENV=test via the `when@test` import in config/routes.yaml, and never
+ * autoloaded outside dev/test composer installs (autoload-dev only) — see
+ * specs/2026-08-18-error-handling/ (Phase 13).
+ */
+class ErrorFixtureController
+{
+    #[Route('/_test/throws-404', name: 'test_throws_404')]
+    public function throws404(): Response
+    {
+        throw new NotFoundHttpException('fixture 404');
+    }
+
+    #[Route('/_test/throws-403', name: 'test_throws_403')]
+    public function throws403(): Response
+    {
+        throw new AccessDeniedHttpException('fixture 403');
+    }
+}

--- a/symfony-app/tests/LegacyBridgeTest.php
+++ b/symfony-app/tests/LegacyBridgeTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Tests;
+
+use App\Exception\LegacyRouteNotFoundException;
+use App\LegacyBridge;
+use App\Service\LegacyErrorPageService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Covers the Phase 13 error-handling changes to LegacyBridge — see
+ * specs/2026-08-18-error-handling/. Deliberately does not cover the
+ * register_shutdown_function fatal path directly: PHP only fires shutdown
+ * functions at real script termination, which isn't observable from within
+ * a single PHPUnit process without ending it. That path's type-filtering
+ * logic is covered by testIsFatalErrorType*() below; the end-to-end
+ * behavior is covered by the manual E2E checklist in validation.md.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class LegacyBridgeTest extends TestCase
+{
+    private string $fixtureDir;
+
+    protected function setUp(): void
+    {
+        $this->fixtureDir = dirname(__DIR__, 2) . '/football/_test_fixtures_phase13';
+        if (!is_dir($this->fixtureDir)) {
+            mkdir($this->fixtureDir, 0775, true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob($this->fixtureDir.'/*.php') ?: []);
+        if (is_dir($this->fixtureDir)) {
+            rmdir($this->fixtureDir);
+        }
+    }
+
+    // ---- getLegacyScript() ----
+
+    public function testGetLegacyScriptThrowsTypedExceptionForUnmappablePath(): void
+    {
+        $request = Request::create('/this-path-does-not-exist-anywhere-xyz');
+
+        $this->expectException(LegacyRouteNotFoundException::class);
+        LegacyBridge::getLegacyScript($request);
+    }
+
+    public function testGetLegacyScriptResolvesARealLegacyFile(): void
+    {
+        file_put_contents($this->fixtureDir.'/hello.php', '<?php // fixture');
+
+        $path = LegacyBridge::getLegacyScript(Request::create('/_test_fixtures_phase13/hello.php'));
+
+        $this->assertSame(realpath($this->fixtureDir.'/hello.php'), $path);
+    }
+
+    // ---- handleRequest(): unmappable path ----
+
+    public function testHandleRequestRendersBranded404ForUnmappablePath(): void
+    {
+        $errorPages = $this->createMock(LegacyErrorPageService::class);
+        $errorPages->expects($this->once())->method('logNotFound');
+        $errorPages->expects($this->once())
+            ->method('renderErrorPage')
+            ->with(404)
+            ->willReturn('<html>404</html>');
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with(LegacyErrorPageService::class)->willReturn($errorPages);
+
+        ob_start();
+        LegacyBridge::handleRequest(
+            Request::create('/this-path-does-not-exist-anywhere-xyz'),
+            new Response(),
+            $container,
+            __DIR__,
+        );
+        $output = ob_get_clean();
+
+        $this->assertSame('<html>404</html>', $output);
+    }
+
+    // ---- handleRequest(): legacy script throws ----
+
+    public function testHandleRequestRendersBranded500WhenLegacyScriptThrows(): void
+    {
+        file_put_contents(
+            $this->fixtureDir.'/throws.php',
+            "<?php throw new \\RuntimeException('legacy boom');",
+        );
+
+        $errorPages = $this->createMock(LegacyErrorPageService::class);
+        $errorPages->expects($this->once())
+            ->method('logFatal')
+            ->with($this->stringContains('throws.php'), $this->isInstanceOf(\RuntimeException::class));
+        $errorPages->expects($this->once())
+            ->method('renderErrorPage')
+            ->with(500)
+            ->willReturn('<html>500</html>');
+
+        ob_start();
+        LegacyBridge::handleRequest(
+            Request::create('/_test_fixtures_phase13/throws.php'),
+            new Response(),
+            $this->mockContainer($errorPages),
+            __DIR__,
+        );
+        $output = ob_get_clean();
+
+        $this->assertSame('<html>500</html>', $output);
+    }
+
+    private function mockContainer(LegacyErrorPageService $errorPages): ContainerInterface
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->method('getManager')->willReturn($em);
+
+        $seasonWeek = $this->getMockBuilder(\App\Service\SeasonWeekService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $seasonWeek->method('getCurrentSeason')->willReturn(2026);
+        $seasonWeek->method('getCurrentWeek')->willReturn(1);
+        $seasonWeek->method('getWeekName')->willReturn('Week 1');
+        $seasonWeek->method('getPreviousWeekName')->willReturn('Week 0');
+        $seasonWeek->method('getPreviousWeek')->willReturn(0);
+        $seasonWeek->method('getPreviousWeekSeason')->willReturn(2026);
+
+        $auth = $this->getMockBuilder(\App\Service\AuthenticationService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $auth->method('isLoggedIn')->willReturn(false);
+        $auth->method('getFullName')->willReturn(null);
+        $auth->method('getTeamNumber')->willReturn(null);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnMap([
+            [LegacyErrorPageService::class, $errorPages],
+            ['doctrine', $doctrine],
+            ['App\Service\SeasonWeekService', $seasonWeek],
+            ['App\Service\AuthenticationService', $auth],
+        ]);
+
+        return $container;
+    }
+
+    // ---- isFatalErrorType() ----
+
+    public function testIsFatalErrorTypeIsFalseForNull(): void
+    {
+        $this->assertFalse(LegacyBridge::isFatalErrorType(null));
+    }
+
+    public function testIsFatalErrorTypeIsFalseForWarningsAndNotices(): void
+    {
+        $this->assertFalse(LegacyBridge::isFatalErrorType($this->error(E_WARNING)));
+        $this->assertFalse(LegacyBridge::isFatalErrorType($this->error(E_NOTICE)));
+        $this->assertFalse(LegacyBridge::isFatalErrorType($this->error(E_DEPRECATED)));
+    }
+
+    public function testIsFatalErrorTypeIsTrueForFatalTypes(): void
+    {
+        foreach ([E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR] as $type) {
+            $this->assertTrue(LegacyBridge::isFatalErrorType($this->error($type)), "type $type should be fatal");
+        }
+    }
+
+    /** @return array{type: int, message: string, file: string, line: int} */
+    private function error(int $type): array
+    {
+        return ['type' => $type, 'message' => 'x', 'file' => 'x.php', 'line' => 1];
+    }
+}

--- a/symfony-app/tests/Service/LegacyErrorPageServiceTest.php
+++ b/symfony-app/tests/Service/LegacyErrorPageServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\LegacyErrorPageService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Twig\Environment;
+
+class LegacyErrorPageServiceTest extends TestCase
+{
+    // ---- renderErrorPage ----
+
+    public function testRenderErrorPageUses404TemplateFor404(): void
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('bundles/TwigBundle/Exception/error404.html.twig')
+            ->willReturn('<html>404</html>');
+
+        $service = new LegacyErrorPageService($twig, $this->createMock(LoggerInterface::class));
+
+        $this->assertSame('<html>404</html>', $service->renderErrorPage(404));
+    }
+
+    public function testRenderErrorPageUses403TemplateFor403(): void
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('bundles/TwigBundle/Exception/error403.html.twig')
+            ->willReturn('<html>403</html>');
+
+        $service = new LegacyErrorPageService($twig, $this->createMock(LoggerInterface::class));
+
+        $this->assertSame('<html>403</html>', $service->renderErrorPage(403));
+    }
+
+    public function testRenderErrorPageFallsBackToGenericTemplateForOtherCodes(): void
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('bundles/TwigBundle/Exception/error.html.twig')
+            ->willReturn('<html>500</html>');
+
+        $service = new LegacyErrorPageService($twig, $this->createMock(LoggerInterface::class));
+
+        $this->assertSame('<html>500</html>', $service->renderErrorPage(500));
+    }
+
+    // ---- logNotFound / logFatal ----
+
+    public function testLogNotFoundLogsAtWarning(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning')->with('no route for /foo');
+
+        $service = new LegacyErrorPageService($this->createMock(Environment::class), $logger);
+        $service->logNotFound('no route for /foo');
+    }
+
+    public function testLogFatalLogsAtErrorWithoutException(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with('boom', []);
+
+        $service = new LegacyErrorPageService($this->createMock(Environment::class), $logger);
+        $service->logFatal('boom');
+    }
+
+    public function testLogFatalAttachesExceptionContext(): void
+    {
+        $exception = new \RuntimeException('legacy fatal');
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')->with('boom', ['exception' => $exception]);
+
+        $service = new LegacyErrorPageService($this->createMock(Environment::class), $logger);
+        $service->logFatal('boom', $exception);
+    }
+}

--- a/symfony-app/tests/bootstrap.php
+++ b/symfony-app/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+// Load .env/.env.local/.env.test.local the same way public/index.php and
+// bin/console do — needed once the suite includes kernel-booting tests
+// (WebTestCase/KernelTestCase; see tests/Controller/ErrorPagesTest.php),
+// since those compile the real container, which resolves %env(DATABASE_URL)%
+// eagerly. Every other test in this suite never boots the kernel, so this
+// was never needed before Phase 13's error-page tests
+// (specs/2026-08-18-error-handling/).
+if (file_exists(dirname(__DIR__).'/.env')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+}


### PR DESCRIPTION
## Summary

Fixes the LegacyBridge fallback's error behavior (roadmap Phase 13): it could no longer tell a genuinely unrouted URL apart from a controller's own `createNotFoundException()`, so both landed in `LegacyBridge`, which then either mis-mapped the request or threw an uncaught exception that bypassed Symfony's exception handling, branded error pages, and Monolog entirely.

- `public/index.php` now falls back to `LegacyBridge` only when the router truly found no route (`_route` attribute unset), not on any 404 status.
- New branded `error404`/`error403`/`error.html.twig` templates under `templates/bundles/TwigBundle/Exception/`, matching site chrome.
- `LegacyBridge::getLegacyScript()`'s "can't map this path" case now throws a typed `LegacyRouteNotFoundException`, caught and rendered as the branded, logged 404 instead of escaping uncaught.
- The legacy `require` is now wrapped in try/catch plus a `register_shutdown_function` fatal-type guard — both paths log via the new `LegacyErrorPageService` and render the branded 500 instead of a raw PHP error dump.
- Prod Monolog's `main` handler floor dropped from `error` to `warning`, closing the previously-invisible 401/403/404 logging gap.
- First `WebTestCase`-based tests in the repo (`tests/Controller/ErrorPagesTest.php`), plus direct-call tests for `LegacyBridge` and `LegacyErrorPageService`.

## Spec

`specs/2026-08-18-error-handling/` (requirements/plan/validation).

## Test plan

- [x] 848 tests green (`vendor/bin/phpunit tests/ --coverage-clover coverage.xml`)
- [ ] Manual E2E checklist in `validation.md` — **not run end-to-end by the agent** (backgrounded `php -S` under a forced prod-like env wasn't reliable in the sandbox; behavior was confirmed instead via synchronous `php -r` reproductions). Please run this checklist for real before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)